### PR TITLE
fix: Correct QuiverQuant API field mappings and truncate asset_ticker

### DIFF
--- a/python-etl-service/app/lib/database.py
+++ b/python-etl-service/app/lib/database.py
@@ -82,7 +82,7 @@ def upload_transaction_to_supabase(
             "disclosure_date": disclosure_date,
             "transaction_type": transaction.get("transaction_type") or "unknown",
             "asset_name": asset_name,
-            "asset_ticker": sanitize_string(transaction.get("asset_ticker")),
+            "asset_ticker": (sanitize_string(transaction.get("asset_ticker")) or "")[:20] or None,
             "asset_type": sanitize_string(
                 transaction.get("asset_type") or transaction.get("asset_type_code")
             ),
@@ -192,7 +192,7 @@ def prepare_transaction_for_batch(
         "disclosure_date": disclosure_date,
         "transaction_type": transaction.get("transaction_type") or "unknown",
         "asset_name": asset_name,
-        "asset_ticker": sanitize_string(transaction.get("asset_ticker")),
+        "asset_ticker": (sanitize_string(transaction.get("asset_ticker")) or "")[:20] or None,
         "asset_type": sanitize_string(
             transaction.get("asset_type") or transaction.get("asset_type_code")
         ),


### PR DESCRIPTION
## Summary
- Fix QuiverQuant ETL to use correct bulk API field names (`Name`, `Traded`, `Filed`, `Chamber`, `Trade_Size_USD`) instead of documented but incorrect names
- Add `asset_ticker` truncation to 20 chars in `database.py` to prevent `VARCHAR(20)` overflow errors from Senate disclosures
- Update all 41 QuiverQuant unit tests to match corrected field mappings

## Test plan
- [x] All 1753 unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Senate ETL e2e test passes all 4 steps (fetch senators, upsert, search EFD, full pipeline)
- [x] No `value too long for type character varying(20)` errors after truncation fix
- [x] QuiverQuant e2e test verified against real API + real Supabase (5 records processed successfully)

## Summary by Sourcery

Align QuiverQuant ETL with the actual bulk API schema and harden transaction ingestion against overlong asset tickers.

Bug Fixes:
- Correct QuiverQuant ETL field mappings to use Name, Trade_Size_USD, Traded, Filed, and Chamber as provided by the bulk API.
- Fix date filtering and parsing logic to rely on Traded and Filed fields for transaction and disclosure dates.
- Ensure politician name parsing and chamber/role mapping use the Chamber and Name fields consistently.
- Prevent VARCHAR(20) overflow errors by truncating asset_ticker values to 20 characters before database insertion.

Enhancements:
- Improve trade size handling by mapping single USD Trade_Size_USD values into standard STOCK Act disclosure brackets and falling back to generic range parsing when needed.
- Enhance state derivation by preferring the State field and only falling back to parsing District when State is missing.
- Strip common prefixes (e.g., Mr., Sen., Rep.) from politician names before splitting into first and last names for more accurate name components.

Tests:
- Update QuiverQuant unit tests to reflect the corrected bulk API schema, trade size parsing, and name/state handling behavior.