### PR TITLE
feat: Add chamber filter to trading disclosures

### DIFF
--- a/client/src/components/LandingTradesTable.tsx
+++ b/client/src/components/LandingTradesTable.tsx
@@ -72,6 +72,13 @@ const PARTY_OPTIONS = [
   { value: 'I', label: 'Independent' },
 ];
 
+// Chamber options
+const CHAMBER_OPTIONS = [
+  { value: '', label: 'All Chambers' },
+  { value: 'Representative', label: 'House' },
+  { value: 'Senator', label: 'Senate' },
+];
+
 // Sortable column configuration
 interface SortableColumn {
   field: SortField;
@@ -104,6 +111,7 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [transactionType, setTransactionType] = useState('');
   const [party, setParty] = useState('');
+  const [chamber, setChamber] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
 
@@ -155,6 +163,7 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
     searchQuery: debouncedSearch || undefined,
     transactionType: transactionType || undefined,
     party: party || undefined,
+    chamber: chamber || undefined,
     dateFrom: dateFrom || undefined,
     dateTo: dateTo || undefined,
     sortField,
@@ -166,7 +175,7 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
   const totalPages = Math.ceil(total / ROWS_PER_PAGE);
 
   // Check if any filters are active
-  const hasActiveFilters = debouncedSearch || transactionType || party || dateFrom || dateTo;
+  const hasActiveFilters = debouncedSearch || transactionType || party || chamber || dateFrom || dateTo;
 
   // Clear all filters
   const clearFilters = () => {
@@ -174,6 +183,7 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
     setDebouncedSearch('');
     setTransactionType('');
     setParty('');
+    setChamber('');
     setDateFrom('');
     setDateTo('');
     setPage(0);
@@ -336,6 +346,20 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
                 </SelectContent>
               </Select>
 
+              {/* Chamber Filter */}
+              <Select value={chamber || 'all'} onValueChange={(v) => { setChamber(v === 'all' ? '' : v); setPage(0); }}>
+                <SelectTrigger className="w-[120px] sm:w-[140px] bg-background/50">
+                  <SelectValue placeholder="Chamber" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CHAMBER_OPTIONS.map((c) => (
+                    <SelectItem key={c.value} value={c.value || 'all'}>
+                      {c.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
               {/* Mobile Date Filter Button */}
               <Dialog open={mobileFilterOpen} onOpenChange={setMobileFilterOpen}>
                 <DialogTrigger asChild>
@@ -474,6 +498,14 @@ const LandingTradesTable = ({ initialSearchQuery, onSearchClear }: LandingTrades
                 <Badge variant="secondary" className="gap-1">
                   Party: {party}
                   <button onClick={() => { setParty(''); setPage(0); }} aria-label="Clear party filter">
+                    <X className="h-3 w-3" aria-hidden="true" />
+                  </button>
+                </Badge>
+              )}
+              {chamber && (
+                <Badge variant="secondary" className="gap-1">
+                  Chamber: {chamber === 'Representative' ? 'House' : 'Senate'}
+                  <button onClick={() => { setChamber(''); setPage(0); }} aria-label="Clear chamber filter">
                     <X className="h-3 w-3" aria-hidden="true" />
                   </button>
                 </Badge>

--- a/client/src/hooks/useSupabaseData.ts
+++ b/client/src/hooks/useSupabaseData.ts
@@ -210,6 +210,7 @@ export const useTradingDisclosures = (options: {
   politicianId?: string;
   transactionType?: string;
   party?: string;
+  chamber?: string;
   searchQuery?: string;
   sortField?: SortField;
   sortDirection?: SortDirection;
@@ -223,6 +224,7 @@ export const useTradingDisclosures = (options: {
     politicianId,
     transactionType,
     party,
+    chamber,
     searchQuery,
     sortField = 'disclosure_date',
     sortDirection = 'desc',
@@ -231,10 +233,11 @@ export const useTradingDisclosures = (options: {
   } = options;
 
   return useQuery({
-    queryKey: ['tradingDisclosures', limit, offset, ticker, politicianId, transactionType, party, searchQuery, sortField, sortDirection, dateFrom, dateTo],
+    queryKey: ['tradingDisclosures', limit, offset, ticker, politicianId, transactionType, party, chamber, searchQuery, sortField, sortDirection, dateFrom, dateTo],
     queryFn: async () => {
-      // Use inner join when filtering by party to enable server-side filtering
-      const selectQuery = party
+      // Use inner join when filtering by party or chamber to enable server-side filtering
+      const needsInnerJoin = party || chamber;
+      const selectQuery = needsInnerJoin
         ? `*, politician:politicians!inner(*)`
         : `*, politician:politicians(*)`;
 
@@ -275,6 +278,10 @@ export const useTradingDisclosures = (options: {
       // Filter by party server-side using the inner join
       if (party) {
         query = query.eq('politician.party', party);
+      }
+      // Filter by chamber (role) server-side using the inner join
+      if (chamber) {
+        query = query.eq('politician.role', chamber);
       }
 
       const { data, error, count } = await query;


### PR DESCRIPTION
## Summary
- Adds a **Chamber** dropdown filter (All Chambers / House / Senate) to the trading disclosures table
- Uses `!inner` join on `politicians` table when either party OR chamber filters are active
- Filter state included in query key, active filter badges, and clear-all logic

## Changes
- `client/src/hooks/useSupabaseData.ts`: Added `chamber` option to `useTradingDisclosures`, updated inner join condition, added `politician.role` filter
- `client/src/components/LandingTradesTable.tsx`: Added `CHAMBER_OPTIONS` constant, `chamber` state, dropdown UI between Party and Date filters, active filter badge

## Test plan
- [x] All 800 client tests pass (`npm test`)
- [ ] Manual: Select "House" — only Representatives appear
- [ ] Manual: Select "Senate" — only Senators appear
- [ ] Manual: Combine chamber + party filter works correctly
- [ ] Manual: Clear filters resets chamber