### PR TITLE
feat: Add mcli + lsh CI/CD deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio pytest-cov pytest-mock
         pip install -r requirements.txt
-      continue-on-error: true
 
     - name: Run ETL tests
       run: |
         pytest tests/ -v --tb=short
-      continue-on-error: true
       env:
         SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://test.supabase.co' }}
         SUPABASE_KEY: ${{ secrets.SUPABASE_KEY || 'test-key' }}
@@ -125,11 +123,62 @@ jobs:
         MIX_ENV: test
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/server_test
 
+  # Deploy to Fly.io (only on push to main, after all tests pass)
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    needs: [etl-tests, client-tests, server-tests]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install zsh
+      run: sudo apt-get update && sudo apt-get install -y zsh
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install UV
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install mcli-framework
+      run: uv tool install mcli-framework
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install lsh-framework
+      run: npm install -g lsh-framework
+
+    - name: Setup IPFS
+      run: mcli self ipfs setup
+
+    - name: Pull mcli workflows from IPFS
+      run: mcli sync pull QmYUmxVLrYm5Qfj4KfBzP5TQsevMGNXiZPN5nVtzm5Yqrg
+
+    - name: Pull secrets via lsh
+      env:
+        LSH_SECRETS_KEY: ${{ secrets.LSH_SECRETS_KEY }}
+      run: lsh pull
+
+    - name: Install Flyctl
+      uses: superfly/flyctl-actions/setup-flyctl@master
+
+    - name: Deploy all services
+      env:
+        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      run: mcli run services deploy-all
+
   # Build Summary
   build-summary:
     name: Build Summary
     runs-on: ubuntu-latest
-    needs: [etl-tests, client-tests, server-tests]
+    needs: [etl-tests, client-tests, server-tests, deploy]
     if: always()
 
     steps:
@@ -142,3 +191,4 @@ jobs:
         echo "| ETL Service | ${{ needs.etl-tests.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| React Client | ${{ needs.client-tests.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Phoenix Server | ${{ needs.server-tests.result }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Deploy to Fly.io | ${{ needs.deploy.result }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from ETL test job to enforce strict test gates before deployment
- Adds a `deploy` job that runs on push to main after all tests pass, using mcli workflows pulled from IPFS and secrets managed by lsh to deploy all three services (ETL, Server, Client) to Fly.io
- Updates `build-summary` to include deploy status in the pipeline summary table

## Prerequisites
Add 2 GitHub repository secrets before the deploy job will work:
1. **`FLY_API_TOKEN`** — get via `flyctl auth token`
2. **`LSH_SECRETS_KEY`** — existing encryption key from local `.env`

## Deploy Pipeline
```
Push to main → Tests pass → Install mcli + lsh + IPFS → Pull workflows → Pull secrets → Deploy ETL → Server → Client
```

## Test plan
- [ ] Verify CI tests still pass on this PR branch (no deploy triggered since not push to main)
- [ ] After merge, verify deploy job triggers on push to main
- [ ] Confirm build-summary table shows deploy status row
- [ ] Check Fly.io dashboard for new deployments after first successful deploy