### PR TITLE
fix: Use lsh sync pull with CID for CI secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
     - name: Pull secrets via lsh
       env:
         LSH_SECRETS_KEY: ${{ secrets.LSH_SECRETS_KEY }}
-      run: lsh pull
+      run: lsh sync pull QmTCuo9F4hhJupvYyCARgTSS9TjU1svXtovU696tZPDtCZ
 
     - name: Install Flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
## Summary
- Fixes deploy job failure where `lsh pull` fails in CI because the fresh IPFS daemon has no cached environment data
- Changed to `lsh sync pull QmTCuo9F4hhJupvYyCARgTSS9TjU1svXtovU696tZPDtCZ` which pulls encrypted secrets directly by CID

## Root Cause
`lsh pull` relies on locally cached IPFS environment metadata. In CI, the IPFS daemon is freshly installed and has no cached data, so it can't resolve the environment. Using `lsh sync pull <CID>` bypasses the environment lookup and fetches directly from the IPFS network.

## Test plan
- [ ] CI tests pass on this PR
- [ ] After merge to main, deploy job should get past the secrets pull step