### PR TITLE
fix: Remove lsh from deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,24 +147,11 @@ jobs:
     - name: Install mcli-framework
       run: uv tool install mcli-framework
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - name: Install lsh-framework
-      run: npm install -g lsh-framework
-
     - name: Setup IPFS
       run: mcli self ipfs setup
 
     - name: Pull mcli workflows from IPFS
       run: mcli sync pull QmYUmxVLrYm5Qfj4KfBzP5TQsevMGNXiZPN5nVtzm5Yqrg
-
-    - name: Pull secrets via lsh
-      env:
-        LSH_SECRETS_KEY: ${{ secrets.LSH_SECRETS_KEY }}
-      run: lsh sync pull QmTCuo9F4hhJupvYyCARgTSS9TjU1svXtovU696tZPDtCZ
 
     - name: Install Flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
## Summary
- Removes Node.js setup, lsh-framework install, and lsh sync pull steps from the deploy job
- `fly deploy` only needs `FLY_API_TOKEN` (already a GitHub Secret), not the app's runtime secrets
- lsh sync pull was failing because locally-pinned IPFS content isn't available on public gateways

## Root Cause
lsh pushes encrypted secrets to the local IPFS node. In CI, the IPFS daemon is fresh and can't resolve the CID from the local network or public gateways (Cloudflare, Pinata). Since `fly deploy` just pushes Docker images and doesn't need runtime secrets, the lsh step was unnecessary.

## Test plan
- [ ] CI tests pass on this PR
- [ ] After merge, deploy job should succeed (all steps pass)