### PR TITLE
fix: Create fly symlink for flyctl in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
     - name: Install Flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
 
+    - name: Create fly symlink
+      run: ln -sf "$(which flyctl)" /usr/local/bin/fly
+
     - name: Deploy all services
       env:
         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `ln -sf $(which flyctl) /usr/local/bin/fly` after flyctl install
- `services.sh` uses `fly deploy` but the flyctl action only adds `flyctl` to PATH
- The zsh subprocess launched by mcli couldn't find the `fly` binary

## Test plan
- [ ] CI tests pass
- [ ] After merge, deploy job gets past the `fly` command not found error