### PR TITLE
fix: Skip amount filter for EU Parliament disclosures

### DIFF
--- a/client/src/hooks/useSupabaseData.ts
+++ b/client/src/hooks/useSupabaseData.ts
@@ -265,7 +265,11 @@ export const useTradingDisclosures = (options: {
       }
 
       // Filter out entries without disclosed amounts (both min and max are null)
-      query = query.or('amount_range_min.not.is.null,amount_range_max.not.is.null');
+      // Skip this filter for EU Parliament — EU DPI declarations often have no amounts
+      const isEUChamber = chamber === 'MEP';
+      if (!isEUChamber) {
+        query = query.or('amount_range_min.not.is.null,amount_range_max.not.is.null');
+      }
 
       if (ticker) {
         query = query.ilike('asset_ticker', `%${ticker}%`);


### PR DESCRIPTION
## Summary
- EU Parliament DPI declarations are interest disclosures (board memberships, shareholdings, employment), not dollar-amount stock trades
- Most EU entries have null `amount_range_min`/`amount_range_max` because they list entity names without EUR values
- The unconditional `or('amount_range_min.not.is.null,amount_range_max.not.is.null')` filter was hiding all EU data
- Now skips this filter when chamber is `MEP`

## Test plan
- [x] 800 client tests pass
- [x] TypeScript compiles clean
- [x] Verify EU Parliament filter shows results after ETL runs