### PR TITLE
fix: Show all politicians regardless of active status

### DIFF
--- a/client/src/hooks/useGlobalSearch.test.ts
+++ b/client/src/hooks/useGlobalSearch.test.ts
@@ -33,14 +33,12 @@ const createWrapper = () => {
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 };
 
-// Helper to create politician mock chain: .select().eq().or().order().limit()
+// Helper to create politician mock chain: .select().or().order().limit()
 const createPoliticianMock = (data: unknown[]) => ({
   select: vi.fn().mockReturnValue({
-    eq: vi.fn().mockReturnValue({
-      or: vi.fn().mockReturnValue({
-        order: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue({ data, error: null }),
-        }),
+    or: vi.fn().mockReturnValue({
+      order: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue({ data, error: null }),
       }),
     }),
   }),

--- a/client/src/hooks/useGlobalSearch.ts
+++ b/client/src/hooks/useGlobalSearch.ts
@@ -26,7 +26,6 @@ export const useGlobalSearch = (query: string) => {
       const { data: politicians } = await supabase
         .from('politicians')
         .select('id, first_name, last_name, full_name, party, role, total_trades')
-        .eq('is_active', true)
         .or(`full_name.ilike.%${searchTerm}%,first_name.ilike.%${searchTerm}%,last_name.ilike.%${searchTerm}%`)
         .order('total_trades', { ascending: false })
         .limit(5);

--- a/client/src/hooks/useSupabaseData.ts
+++ b/client/src/hooks/useSupabaseData.ts
@@ -117,7 +117,6 @@ export const usePoliticians = (jurisdictionId?: string) => {
       let query = supabase
         .from('politicians')
         .select('*')
-        .eq('is_active', true)
         .order('total_volume', { ascending: false });
 
       if (jurisdictionId) {

--- a/python-etl-service/app/lib/politician.py
+++ b/python-etl-service/app/lib/politician.py
@@ -144,6 +144,7 @@ def find_or_create_politician(
             "role": role,
             "party": party,
             "state": state,
+            "is_active": True,
         }
 
         # Add bioguide_id if provided

--- a/supabase/migrations/20260212180000_reactivate_all_politicians.sql
+++ b/supabase/migrations/20260212180000_reactivate_all_politicians.sql
@@ -1,0 +1,81 @@
+-- Reactivate all politicians regardless of disclosure count.
+-- The frontend serves as a public outreach tool tracking both current and
+-- historical politicians, so is_active should always be true.
+--
+-- Also updates the trigger to re-activate politicians when disclosures are added.
+
+BEGIN;
+
+-- =============================================================================
+-- Step 1: Reactivate all politicians
+-- =============================================================================
+UPDATE politicians SET is_active = true WHERE is_active = false;
+
+-- =============================================================================
+-- Step 2: Update trigger to re-activate politicians when disclosures are added
+-- =============================================================================
+CREATE OR REPLACE FUNCTION update_politician_stats()
+RETURNS TRIGGER AS $$
+DECLARE
+  affected_politician_id UUID;
+BEGIN
+  -- Determine which politician_id to update
+  IF TG_OP = 'DELETE' THEN
+    affected_politician_id := OLD.politician_id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- If politician_id changed, update both old and new
+    IF OLD.politician_id IS DISTINCT FROM NEW.politician_id THEN
+      -- Recompute old politician
+      UPDATE politicians SET
+        total_trades = COALESCE((
+          SELECT COUNT(*) FROM trading_disclosures
+          WHERE politician_id = OLD.politician_id
+            AND status = 'active' AND deleted_at IS NULL
+        ), 0),
+        total_volume = COALESCE((
+          SELECT SUM((COALESCE(amount_range_min, 0) + COALESCE(amount_range_max, 0)) / 2)
+          FROM trading_disclosures
+          WHERE politician_id = OLD.politician_id
+            AND status = 'active' AND deleted_at IS NULL
+        ), 0)
+      WHERE id = OLD.politician_id;
+    END IF;
+    affected_politician_id := NEW.politician_id;
+  ELSE
+    affected_politician_id := NEW.politician_id;
+  END IF;
+
+  -- Skip if no politician_id
+  IF affected_politician_id IS NULL THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    ELSE
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  -- Recompute stats for the affected politician and ensure they are active
+  UPDATE politicians SET
+    total_trades = COALESCE((
+      SELECT COUNT(*) FROM trading_disclosures
+      WHERE politician_id = affected_politician_id
+        AND status = 'active' AND deleted_at IS NULL
+    ), 0),
+    total_volume = COALESCE((
+      SELECT SUM((COALESCE(amount_range_min, 0) + COALESCE(amount_range_max, 0)) / 2)
+      FROM trading_disclosures
+      WHERE politician_id = affected_politician_id
+        AND status = 'active' AND deleted_at IS NULL
+    ), 0),
+    is_active = true
+  WHERE id = affected_politician_id;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Remove `is_active` filtering from `usePoliticians` and `useGlobalSearch` hooks — all politicians (current and historical) are now visible in the UI
- Add `is_active=True` explicitly to `find_or_create_politician` so new EU MEPs are always visible
- Add DB migration to reactivate all deactivated politicians and update the stats trigger to set `is_active=true` when disclosures are inserted

## Root Cause
The orphan cleanup migration (`20260211`) deactivated any politician with zero trading disclosures. When the EU ETL created ~50 MEPs before being killed by a deploy restart, those MEPs had no disclosures yet and were deactivated. Combined with the client filtering by `is_active=true`, EU Parliament showed 0 results.

## Test plan
- [x] All 1936 Python tests pass
- [x] All 800 client tests pass (updated mock chain in useGlobalSearch.test.ts)
- [ ] After deploy, verify all politicians appear in the UI
- [ ] Re-trigger EU ETL and verify MEPs + declarations populate