### PR TITLE
fix: Resolve production 500 errors from statement timeouts

### DIFF
--- a/client/src/hooks/useSupabaseData.ts
+++ b/client/src/hooks/useSupabaseData.ts
@@ -253,7 +253,7 @@ export const useTradingDisclosures = (options: {
 
       let query = supabase
         .from('trading_disclosures')
-        .select(selectQuery, { count: 'exact' })
+        .select(selectQuery, { count: 'estimated' })
         .eq('status', 'active')
         .order(sortField, { ascending: sortDirection === 'asc' })
         .range(offset, offset + limit - 1);

--- a/python-etl-service/app/lib/database.py
+++ b/python-etl-service/app/lib/database.py
@@ -16,6 +16,25 @@ def get_supabase() -> Optional[Client]:
         return None
     return create_client(supabase_url, supabase_key)
 
+def refresh_materialized_views(supabase_client: Optional[Client] = None) -> bool:
+    """Refresh materialized views after ETL data imports.
+
+    Calls the refresh_top_tickers() database function to update the
+    pre-computed top_tickers materialized view with fresh data.
+    """
+    try:
+        client = supabase_client or get_supabase()
+        if not client:
+            logger.warning("No Supabase client available for materialized view refresh")
+            return False
+        client.rpc("refresh_top_tickers").execute()
+        logger.info("Refreshed top_tickers materialized view")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to refresh materialized views: {e}")
+        return False
+
+
 def upload_transaction_to_supabase(
     supabase_client: Client,
     politician_id: str,

--- a/python-etl-service/app/routes/etl.py
+++ b/python-etl-service/app/routes/etl.py
@@ -33,6 +33,7 @@ from app.services.senate_backfill import run_senate_backfill
 
 # New framework imports
 from app.lib import ETLRegistry
+from app.lib.database import refresh_materialized_views
 
 # Register services (import triggers registration)
 import app.services.etl_services  # noqa: F401
@@ -123,6 +124,7 @@ async def _run_registry_service(source: str, job_id: str, **kwargs):
                 f"{result.records_skipped} skipped, "
                 f"{result.records_failed} failed"
             )
+            refresh_materialized_views()
         else:
             JOB_STATUS[job_id]["message"] = f"Failed: {'; '.join(result.errors)}"
 

--- a/python-etl-service/app/services/house_etl.py
+++ b/python-etl-service/app/services/house_etl.py
@@ -25,7 +25,7 @@ from app.lib.parser import (
     clean_asset_name,
     is_header_row,
 )
-from app.lib.database import get_supabase, upload_transaction_to_supabase
+from app.lib.database import get_supabase, upload_transaction_to_supabase, refresh_materialized_views
 from app.lib.pdf_utils import extract_text_from_pdf, extract_tables_from_pdf
 from app.lib.politician import find_or_create_politician
 from app.lib.job_logger import log_job_execution, cleanup_old_executions
@@ -774,6 +774,9 @@ async def run_house_etl(
                     "rate_limiter_stats": stats,
                 },
             )
+
+            # Refresh materialized views with new data
+            refresh_materialized_views(supabase_client)
 
             # Cleanup old records (1% chance per run)
             import random

--- a/python-etl-service/app/services/senate_etl.py
+++ b/python-etl-service/app/services/senate_etl.py
@@ -38,7 +38,7 @@ from app.lib.parser import (
     clean_asset_name,
     is_header_row,
 )
-from app.lib.database import get_supabase, upload_transaction_to_supabase
+from app.lib.database import get_supabase, upload_transaction_to_supabase, refresh_materialized_views
 from app.lib.pdf_utils import extract_text_from_pdf, extract_tables_from_pdf
 from app.lib.politician import find_or_create_politician
 from app.lib.job_logger import log_job_execution, cleanup_old_executions
@@ -1409,6 +1409,9 @@ async def run_senate_etl(
                 "discovery_tier": discovery_tier,
             },
         )
+
+        # Refresh materialized views with new data
+        refresh_materialized_views(supabase)
 
         # Cleanup old records (1% chance per run)
         import random


### PR DESCRIPTION
## Summary
- **Root cause**: Supabase `anon` role has a strict statement timeout (~3s). Two queries exceeded it:
  1. `top_tickers` view — full aggregation of 133k rows with MODE()/UPPER() on every request
  2. `trading_disclosures` with `count=exact` — forces full row count of ~100k+ filtered rows
- The `top_tickers` materialized view migration was already applied in a prior session (migration `20260213000000`)
- This PR fixes the remaining `trading_disclosures` timeout and adds ETL post-import refresh hooks

## Changes
- **`useSupabaseData.ts`**: `count: 'exact'` → `count: 'estimated'` — uses PostgreSQL row estimate instead of full count
- **`database.py`**: New `refresh_materialized_views()` helper that calls `refresh_top_tickers()` RPC
- **`house_etl.py`**, **`senate_etl.py`**, **`etl.py`**: Call refresh after successful imports to keep the materialized view fresh

## Test plan
- [x] Verified `top_tickers` returns 200 in 0.43s with anon key (was 500 timeout)
- [x] Verified `trading_disclosures` returns 200 without count=exact
- [x] All 1936 Python ETL tests pass
- [x] All 800 frontend tests pass