### PR TITLE
fix: resolve 500 errors on chamber/party filter queries

### DIFF
--- a/supabase/migrations/20260213100000_add_politician_join_indexes.sql
+++ b/supabase/migrations/20260213100000_add_politician_join_indexes.sql
@@ -1,0 +1,42 @@
+-- Fix 500 errors on trading_disclosures queries that filter by politician attributes
+-- (e.g., chamber/role, party) via PostgREST inner joins.
+--
+-- Root cause: No index on trading_disclosures.politician_id means every inner join
+-- with politicians requires a sequential scan of 125K+ rows. Combined with
+-- the anon role's statement timeout, this causes consistent 500 errors.
+
+-- Step 1: Add index on the foreign key used for ALL politician joins
+CREATE INDEX IF NOT EXISTS idx_disclosures_politician_id
+  ON trading_disclosures(politician_id);
+
+-- Step 2: Compound index for the most common filtered join pattern:
+-- WHERE status='active' joined on politician_id, ordered by disclosure_date
+CREATE INDEX IF NOT EXISTS idx_disclosures_status_politician_date
+  ON trading_disclosures(status, politician_id, disclosure_date DESC);
+
+-- Step 3: Add index on politicians.role for chamber filtering (MEP, Senator, Representative)
+CREATE INDEX IF NOT EXISTS idx_politicians_role
+  ON politicians(role);
+
+-- Step 4: Add index on politicians.party for party filtering
+CREATE INDEX IF NOT EXISTS idx_politicians_party
+  ON politicians(party)
+  WHERE party IS NOT NULL;
+
+-- Step 5: Clean up garbage EU Parliament placeholder data
+-- These 30 records were created by a test run, not the real EU ETL:
+-- - All tied to a single "EU MEP (Placeholder)" politician
+-- - Source URLs point to CSS files instead of actual disclosure PDFs
+-- - Asset names are all "EU Asset" (not real financial interests)
+-- - All have status='pending'
+DELETE FROM trading_disclosures
+WHERE politician_id IN (
+  SELECT id FROM politicians WHERE full_name = 'EU MEP (Placeholder)'
+);
+
+DELETE FROM politicians
+WHERE full_name = 'EU MEP (Placeholder)';
+
+-- Step 6: Update statistics for query planner after index creation
+ANALYZE trading_disclosures;
+ANALYZE politicians;


### PR DESCRIPTION
## Summary
- Add missing `politician_id` index on `trading_disclosures` table — root cause of 500 errors when filtering by chamber (EU Parliament, Senate, House) or party via PostgREST inner joins
- Add compound index `(status, politician_id, disclosure_date DESC)` for the filtered-joined-sorted query pattern
- Add `politicians.role` and `politicians.party` indexes for filter performance
- Clean up 30 garbage EU Parliament placeholder disclosures (CSS URLs, "EU Asset" names from test run)
- Add `mcli run etl eu-trigger` command for EU Parliament ETL

## Root Cause
The frontend uses PostgREST `!inner` joins when filtering by chamber or party, generating SQL like:
```sql
SELECT * FROM trading_disclosures
INNER JOIN politicians ON politician_id = politicians.id
WHERE status = 'active' AND politicians.role = 'MEP'
```
Without an index on `politician_id`, this required a sequential scan of 125K+ rows, exceeding the 4-second anon role statement timeout.

## Test plan
- [x] EU Parliament filter query: 500 → 200 (1.99s with service key)
- [x] Senate filter: 200 in 0.71s
- [x] House filter: 200 in 0.92s
- [x] Placeholder data cleaned up (verified via API)
- [x] Migration deployed to production via `supabase db push`
- [ ] EU Parliament ETL triggered and running (job 1f372c1b, processing 736 MEPs)