### PR TITLE
fix: preserve real PDF source URLs for trading disclosures

### DIFF
--- a/python-etl-service/tests/test_quiver_etl.py
+++ b/python-etl-service/tests/test_quiver_etl.py
@@ -364,6 +364,15 @@ class TestParseDisclosure:
         assert result["transaction_date"] == "2025-01-15"
         assert result["disclosure_date"] == "2025-01-20"
 
+    @pytest.mark.asyncio
+    async def test_source_url_is_none(self):
+        """QQ is for validation only — source_url should be None (primary sources provide PDF links)."""
+        service = QuiverQuantETLService()
+        raw = _qq_record(Chamber="Representatives")
+        result = await service.parse_disclosure(raw)
+
+        assert result["source_url"] is None
+
 
 # =============================================================================
 # validate_disclosure() Tests

--- a/supabase/migrations/20260213120000_backfill_source_url_quiverquant.sql
+++ b/supabase/migrations/20260213120000_backfill_source_url_quiverquant.sql
@@ -1,0 +1,18 @@
+-- Backfill source_url for QuiverQuant records that have NULL source_url.
+--
+-- QuiverQuant ETL previously set source_url to NULL because the API
+-- doesn't provide direct PDF links. We now link to the official
+-- government disclosure search pages based on politician chamber/role.
+--
+-- House Representatives -> House Clerk Financial Disclosure search
+-- Senators -> Senate EFD (Electronic Financial Disclosure) search
+
+UPDATE trading_disclosures td
+SET source_url = CASE
+    WHEN p.role = 'Senator' THEN 'https://efdsearch.senate.gov/search/'
+    ELSE 'https://disclosures-clerk.house.gov/PublicSearch'
+END
+FROM politicians p
+WHERE td.politician_id = p.id
+  AND td.source_url IS NULL
+  AND td.source_document_id LIKE 'qq-%';

--- a/supabase/migrations/20260213130000_fix_source_url_quiverquant.sql
+++ b/supabase/migrations/20260213130000_fix_source_url_quiverquant.sql
@@ -1,0 +1,33 @@
+-- Fix: Revert generic search page URLs on QuiverQuant validation records.
+--
+-- QuiverQuant is used for validation only, not as a primary data source.
+-- The previous migration incorrectly set generic search page URLs on QQ
+-- records. The real source_url should come from direct House/Senate ETL
+-- scraping which provides actual PDF disclosure links.
+--
+-- Step 1: Revert generic URLs back to NULL for QQ records
+-- Step 2: For QQ records that have a matching House/Senate counterpart
+--         (same politician, date, ticker, type), copy the real PDF URL
+
+-- Step 1: Clear the generic search page URLs from QQ records
+UPDATE trading_disclosures
+SET source_url = NULL
+WHERE source_document_id LIKE 'qq-%'
+  AND (
+    source_url = 'https://disclosures-clerk.house.gov/PublicSearch'
+    OR source_url = 'https://efdsearch.senate.gov/search/'
+  );
+
+-- Step 2: Copy real PDF URLs from matching House/Senate records
+-- Match on: same politician, same transaction date, same ticker, same type
+UPDATE trading_disclosures qq
+SET source_url = match.source_url
+FROM trading_disclosures match
+WHERE qq.source_document_id LIKE 'qq-%'
+  AND qq.source_url IS NULL
+  AND match.source_document_id NOT LIKE 'qq-%'
+  AND match.source_url IS NOT NULL
+  AND qq.politician_id = match.politician_id
+  AND qq.transaction_date = match.transaction_date
+  AND qq.asset_ticker = match.asset_ticker
+  AND qq.transaction_type = match.transaction_type;


### PR DESCRIPTION
## Summary
- Reverts incorrect backfill that set generic search page URLs on QuiverQuant validation records
- QQ records now correctly have NULL source_url (QQ is for validation only, not primary data)
- For the 8 QQ records that have matching House/Senate counterparts, copies the real PDF URL
- Adds test confirming QQ parse_disclosure returns source_url=None

## Context
QuiverQuant API doesn't provide disclosure PDF links. The real source URLs come from House ETL (direct PDF links like `https://disclosures-clerk.house.gov/public_disc/ptr-pdfs/2026/{doc_id}.pdf`) and Senate ETL (EFD filing links).

## Test plan
- [x] `test_source_url_is_none` confirms QQ ETL sets source_url to None
- [x] All 42 QQ ETL tests pass
- [x] Migration deployed and verified — House records retain PDF URLs, QQ records have NULL