### PR TITLE
fix: remove QuiverQuant records from public disclosures

### DIFF
--- a/supabase/migrations/20260213140000_remove_quiverquant_records.sql
+++ b/supabase/migrations/20260213140000_remove_quiverquant_records.sql
@@ -1,0 +1,23 @@
+-- Remove QuiverQuant-sourced records from trading_disclosures.
+--
+-- QuiverQuant data is used internally for validation only and should
+-- not be published publicly. All public disclosure data should come
+-- directly from official government sources (House Clerk, Senate EFD).
+--
+-- Two populations of QQ records exist:
+-- 1. qq-prefixed source_document_id (e.g., qq-P000197-2026-01-16-GOOGL)
+-- 2. Older batch with source_url pointing to quiverquant.com
+
+-- Remove QQ-prefixed records
+DELETE FROM trading_disclosures
+WHERE source_document_id LIKE 'qq-%';
+
+-- Remove older QQ batch (source_url = quiverquant.com)
+DELETE FROM trading_disclosures
+WHERE source_url LIKE '%quiverquant.com%';
+
+-- Refresh materialized views after data removal
+SELECT refresh_top_tickers();
+
+-- Update statistics
+ANALYZE trading_disclosures;


### PR DESCRIPTION
## Summary
- Removes ~1,042 QuiverQuant-sourced records from `trading_disclosures`
- QQ data is for internal validation only, not for public display
- All remaining 126,249 records come from official government sources with real PDF links
- Refreshes materialized views after cleanup

## Test plan
- [x] Migration deployed and verified
- [x] Zero QQ records remain (`source_document_id LIKE 'qq-%'` returns 0)
- [x] Zero null `source_url` records remain
- [x] All remaining records have real PDF source URLs
- [x] Landing page Source column now shows clickable links for all records