### PR TITLE
fix: add auth to mcli ETL commands, fix EU Parliament limit

### DIFF
--- a/python-etl-service/app/services/eu_etl.py
+++ b/python-etl-service/app/services/eu_etl.py
@@ -102,7 +102,7 @@ class EUParliamentETLService(BaseETLService):
         Returns:
             List of parsed financial interest records ready for upload.
         """
-        limit_meps = kwargs.get("limit_meps")
+        limit_meps = kwargs.get("limit_meps") or kwargs.get("limit")
         include_former = kwargs.get("include_former", True)
         year_start = kwargs.get("year_start", 2015)
         all_records: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- All mcli ETL commands now authenticate via `X-API-Key` header (loaded from `.env`)
- Added `_etl_post()` / `_etl_get()` helpers to centralize auth
- Fixed EU Parliament ETL: trigger passes `limit` but `fetch_disclosures` expected `limit_meps`
- EU ETL now accepts both `limit` and `limit_meps` kwargs

## Test plan
- [x] `mcli run etl eu-trigger --limit 3` no longer returns 401
- [x] `python3 -c "import ast; ..."` confirms no syntax errors
- [x] EU ETL job starts and processes correctly with limit