### PR TITLE
fix: forward limit parameter to fetch_disclosures in BaseETLService

### DIFF
--- a/python-etl-service/app/lib/base_etl.py
+++ b/python-etl-service/app/lib/base_etl.py
@@ -357,8 +357,13 @@ class BaseETLService(ABC):
             await self.on_start(job_id, **kwargs)
 
             # Fetch raw disclosures
+            # Forward limit to fetch_disclosures so sources can optimise
+            # their fetch phase (e.g. EU ETL limits MEPs before scraping).
             self.update_job_status(job_id, message="Fetching disclosures...")
-            raw_disclosures = await self.fetch_disclosures(**kwargs)
+            fetch_kwargs = {**kwargs}
+            if limit is not None:
+                fetch_kwargs.setdefault("limit", limit)
+            raw_disclosures = await self.fetch_disclosures(**fetch_kwargs)
 
             if not raw_disclosures:
                 result.add_warning("No disclosures fetched from source")

--- a/python-etl-service/app/services/eu_etl.py
+++ b/python-etl-service/app/services/eu_etl.py
@@ -147,10 +147,9 @@ class EUParliamentETLService(BaseETLService):
                 mep_id = mep["mep_id"]
                 full_name = mep["full_name"]
 
-                if (i + 1) % 50 == 0:
-                    self.logger.info(
-                        f"Processing MEP {i + 1}/{len(meps)}: {full_name}"
-                    )
+                self.logger.info(
+                    f"Processing MEP {i + 1}/{len(meps)}: {full_name}"
+                )
 
                 # Upsert politician
                 first_name, last_name = _split_mep_name(full_name)


### PR DESCRIPTION
## Summary
- The `limit` parameter was captured by `BaseETLService.run()` as a named arg but never forwarded to `fetch_disclosures(**kwargs)`, causing EU ETL to process all 700+ MEPs even with `limit=3`
- Added `limit` to the kwargs dict passed to `fetch_disclosures()` using `setdefault` to avoid overriding source-specific limit params
- Improved MEP processing logs to show every MEP (not just every 50th) for better observability

## Test plan
- [x] All 110 EU ETL tests pass
- [x] All 122 QuiverQuant tests pass
- [ ] Deploy and trigger EU ETL with `--limit 3` to verify it completes