### PR TITLE
fix: EU Parliament DPI PDF parsing for real document format

### DIFF
--- a/python-etl-service/tests/test_eu_etl.py
+++ b/python-etl-service/tests/test_eu_etl.py
@@ -947,7 +947,7 @@ Real estate holdings
     def test_very_long_entity_name_truncated(self):
         """Entity names should be capped at 200 chars in records."""
         long_name = "A" * 300
-        text = f"D. Shareholdings\n\n{long_name}"
+        text = f"D. Shareholdings\n\n1. {long_name}"
         interests = extract_financial_interests(text)
         # The entity from _parse_section_entries may be long, but
         # the ETL service truncates in fetch_disclosures


### PR DESCRIPTION
## Summary
- Fixed section header regex to match actual DPI format `(A)` instead of only `A.`
- Added comprehensive boilerplate skip patterns for DPI description text
- Fixed `_parse_section_entries` to not create entries from pre-numbered-item description text
- Added INFO-level logging to EU ETL pipeline for observability

Verified against real DPI PDFs:
- Mika AALTOLA: 1 interest extracted (Board Member, Arctic Center)
- Magdalena ADAMOWICZ: 10 interests extracted (5 income, 4 boards, 1 shareholding)

## Test plan
- [x] All 110 EU ETL tests pass
- [ ] Deploy and trigger EU ETL with `--limit 3` to verify records are inserted