### PR TITLE
fix: filter multilingual boilerplate from EU Parliament DPI parser

### DIFF
--- a/python-etl-service/app/services/eu_etl.py
+++ b/python-etl-service/app/services/eu_etl.py
@@ -303,7 +303,7 @@ class EUParliamentETLService(BaseETLService):
         upload_disclosure().
         """
         asset_name = raw.get("asset_name", "")
-        if not asset_name or len(asset_name.strip()) < 2:
+        if not asset_name or len(asset_name.strip()) < 5:
             return None
 
         return {
@@ -465,20 +465,6 @@ def _parse_section_entries(
                 "text": " ".join(current_entry_lines),
                 "raw_lines": current_entry_lines.copy(),
             }
-        )
-
-    # If no numbered items were found, try treating meaningful lines
-    # as individual entries (for sections without numbered lists)
-    if not entries and meaningful_lines:
-        # Only include lines that look like actual entity names (short, no colons)
-        for line in meaningful_lines:
-            if len(line) < 150 and ":" not in line:
-                entries.append(
-                    {
-                        "entity": line[:200],
-                        "text": line,
-                        "raw_lines": [line],
-                    }
         )
 
     return entries


### PR DESCRIPTION
## Summary

- Remove non-numbered fallback in `_parse_section_entries()` that was too permissive for non-English DPI PDFs
- Increase minimum `asset_name` length from 2 to 5 characters to reject country codes (ES, FR) and abbreviations
- Add tests for Spanish boilerplate rejection and country code filtering

## Problem

Non-English DPI PDFs (Spanish, French, etc.) produced bogus entries because:
1. `SKIP_PATTERNS` only contained English boilerplate phrases
2. The non-numbered fallback captured any line < 150 chars without colons
3. Minimum asset_name length of 2 failed to filter entries like "ES"

## Approach

DPI financial interests are **always numbered** (1., 2., etc.) in the official format. Instead of enumerating boilerplate in 24 languages, we flip to deny-by-default: only extract numbered items.

## Test plan

- [x] All 112 EU ETL tests pass
- [x] `test_non_numbered_entries_rejected` - non-numbered content produces 0 entries
- [x] `test_spanish_boilerplate_rejected` - Spanish DPI boilerplate produces 0 entries
- [x] `test_skips_country_code_asset_name` - ES, EUR, AAPL rejected by length filter
- [x] `test_un_numbered_single_entry_rejected` - single non-numbered entry rejected

## Summary by Sourcery

Tighten EU Parliament DPI parsing to only accept clearly numbered financial interest entries and ignore ambiguous short asset identifiers.

Bug Fixes:
- Reject non-numbered DPI content so multilingual boilerplate and unstructured lines are not misinterpreted as financial interest entries.
- Increase the minimum asset_name length threshold so country codes and short abbreviations are not treated as valid assets.

Tests:
- Add tests ensuring non-numbered DPI sections, including Spanish boilerplate examples, yield no parsed financial interests.
- Add tests verifying single unnumbered entries and short asset names like ES, EUR, and AAPL are rejected by the parser.