### PR TITLE
fix: delete stale QuiverQuant and EU boilerplate records

### DIFF
--- a/supabase/migrations/20260215170000_cleanup_qq_and_eu_boilerplate.sql
+++ b/supabase/migrations/20260215170000_cleanup_qq_and_eu_boilerplate.sql
@@ -1,0 +1,35 @@
+-- Clean up stale QuiverQuant records and EU Parliament boilerplate disclosures.
+--
+-- Two issues addressed:
+--
+-- 1. QuiverQuant records (source_document_id LIKE 'qq-%') re-appeared after
+--    the Feb 13 cleanup migration because the QQ ETL ran again on Feb 11-12.
+--    These records have null source_url and show "-" in the frontend Source column.
+--
+-- 2. EU Parliament DPI records (source_document_id LIKE 'DPI-%') were ingested
+--    before the multilingual boilerplate fix (PR #167) was deployed, so
+--    Croatian/Spanish/French column headers leaked into asset_name fields.
+--    Rather than surgically identifying bad records, we delete ALL EU records
+--    and re-trigger the EU ETL with the fixed parser for a clean re-ingestion.
+
+BEGIN;
+
+-- 1. Remove QuiverQuant records (re-inserted after previous cleanup)
+DELETE FROM trading_disclosures
+WHERE source_document_id LIKE 'qq-%';
+
+-- Remove any older QQ batch with quiverquant.com source URLs
+DELETE FROM trading_disclosures
+WHERE source_url LIKE '%quiverquant.com%';
+
+-- 2. Remove ALL EU Parliament DPI records for clean re-ingestion
+DELETE FROM trading_disclosures
+WHERE source_document_id LIKE 'DPI-%';
+
+COMMIT;
+
+-- Refresh materialized views after bulk deletion
+SELECT refresh_top_tickers();
+
+-- Update table statistics for query planner
+ANALYZE trading_disclosures;


### PR DESCRIPTION
## Summary
- Deletes re-appeared QuiverQuant records (`source_document_id LIKE 'qq-%'`) that were re-inserted after the Feb 13 cleanup
- Deletes ALL EU Parliament DPI records (`source_document_id LIKE 'DPI-%'`) contaminated with multilingual boilerplate before the parser fix (PR #167)
- Refreshes materialized views after cleanup

## Context
After deploying the multilingual boilerplate fix (#167), we discovered ~560 QQ records re-appeared (showing "-" in Source column) and ~31,976 EU records contain Croatian/Spanish/French column headers as asset names. Clean-slate deletion + EU ETL re-trigger is safer than surgical filtering.

## Test plan
- [ ] Run migration against production Supabase
- [ ] Verify 0 records with `source_document_id LIKE 'qq-%'`
- [ ] Verify 0 records with `source_document_id LIKE 'DPI-%'`
- [ ] Re-trigger EU Parliament ETL
- [ ] Verify new EU records have clean asset names (no boilerplate)
- [ ] Check site Source column shows links for all records

## Summary by Sourcery

Clean up stale QuiverQuant and EU Parliament trading disclosure records and refresh related database metadata.

Bug Fixes:
- Remove reappeared QuiverQuant trading disclosure records, including those with quiverquant.com source URLs, to eliminate stale entries.
- Delete all EU Parliament DPI trading disclosure records contaminated by multilingual boilerplate to prepare for clean re-ingestion.

Enhancements:
- Refresh materialized views and update statistics on the trading_disclosures table after bulk deletions to maintain query accuracy and performance.