### PR TITLE
fix: resolve MEP filter timeout and backfill House party data

### DIFF
--- a/python-etl-service/app/lib/politician.py
+++ b/python-etl-service/app/lib/politician.py
@@ -62,6 +62,9 @@ def find_or_create_politician(
         # Check if disclosure has bioguide_id
         if not bioguide_id:
             bioguide_id = disclosure.get("bioguide_id")
+        # Use party from disclosure if not already provided
+        if not party:
+            party = disclosure.get("party")
 
     # Build full name if not provided
     if not name and (first_name or last_name):

--- a/supabase/migrations/20260216090000_add_covering_index_politicians_role.sql
+++ b/supabase/migrations/20260216090000_add_covering_index_politicians_role.sql
@@ -1,0 +1,9 @@
+-- Add covering index on politicians(role, id) to speed up PostgREST joins
+-- filtered by role. This allows index-only scans when finding all politician
+-- IDs for a given role (e.g. 'MEP', 'Senator', 'Representative').
+CREATE INDEX IF NOT EXISTS idx_politicians_role_id
+  ON politicians(role, id);
+
+-- Update table statistics for optimal query planning
+ANALYZE politicians;
+ANALYZE trading_disclosures;


### PR DESCRIPTION
## Summary

- **Fix MEP filter 500 timeout**: Pre-queries politician IDs for the selected chamber/party filter before building the main disclosures query. Short-circuits to empty results when zero politicians match (preventing the 126K-row full table scan that caused the PostgreSQL statement timeout). Uses `IN` clause for small politician sets instead of the expensive PostgREST inner join filter.
- **Backfill House party data**: House disclosure PDFs don't contain party affiliation, leaving ~1000+ Representatives with NULL party (displayed as "Other"). The House ETL now fetches party data from the free `@unitedstates` legislators dataset at startup and injects it into each disclosure. A post-ETL backfill step also updates existing NULL-party politicians.
- **Add covering index**: `politicians(role, id)` covering index improves join performance for role-based queries.

## Test plan

- [x] All 800 frontend tests pass (Vitest)
- [x] All 1,940 ETL service tests pass (pytest)
- [ ] Verify MEP filter no longer returns 500 on production
- [ ] Run House ETL to confirm party backfill works
- [ ] Verify "Other" party display is reduced after ETL run

## Summary by Sourcery

Resolve trading disclosure filter timeouts and enrich House data with party affiliations.

Bug Fixes:
- Prevent trading disclosure queries filtered by chamber or party from timing out by avoiding expensive inner joins when the filter matches few or no politicians.

Enhancements:
- Pre-query relevant politician IDs and use an IN-clause strategy for chamber/party filters to improve trading disclosure query performance.
- Add a covering index on politicians(role, id) and analyze key tables to speed up role-based lookups and joins.
- Propagate party information from House disclosures into politician records during ETL processing.
- Enrich House disclosure data with party affiliations from the public @unitedstates legislators dataset, including a backfill for existing Representative records with missing party values.