### PR TITLE
test: add unit tests for all network-dependent UI hooks

### DIFF
--- a/client/src/hooks/useAdmin.test.ts
+++ b/client/src/hooks/useAdmin.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for hooks/useAdmin.ts
+ *
+ * Tests:
+ * - useAdmin() - Checks admin role via auth session + RPC
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+// Mock Supabase client
+const mockGetSession = vi.fn();
+const mockRpc = vi.fn();
+const mockOnAuthStateChange = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+      onAuthStateChange: (cb: () => void) => {
+        mockOnAuthStateChange(cb);
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      },
+    },
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+  supabasePublic: {
+    auth: { getSession: () => mockGetSession() },
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logError: vi.fn(),
+}));
+
+import { useAdmin } from './useAdmin';
+
+describe('useAdmin()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns isAdmin=false when no session', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('returns isAdmin=false on session error', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Session expired' },
+    });
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('returns isAdmin=true when has_role RPC returns true', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: 'user-123' } } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAdmin).toBe(true);
+    expect(mockRpc).toHaveBeenCalledWith('has_role', {
+      _user_id: 'user-123',
+      _role: 'admin',
+    });
+  });
+
+  it('returns isAdmin=false when has_role returns false', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: 'user-456' } } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('returns isAdmin=false when RPC errors', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: 'user-789' } } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'RPC failed' } });
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('starts in loading state', () => {
+    mockGetSession.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(() => useAdmin());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('subscribes to auth state changes', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    renderHook(() => useAdmin());
+    await waitFor(() => expect(mockOnAuthStateChange).toHaveBeenCalled());
+  });
+});

--- a/client/src/hooks/useAlpacaAccount.test.ts
+++ b/client/src/hooks/useAlpacaAccount.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for hooks/useAlpacaAccount.ts and useAlpacaPositions.ts
+ *
+ * Tests:
+ * - useAlpacaAccount() - Fetches Alpaca account data from edge function
+ * - calculateDailyPnL() - Daily P&L calculation helper
+ * - useAlpacaPositions() - Fetches Alpaca positions from edge function
+ * - calculatePositionMetrics() - Position metrics calculation helper
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock Supabase client
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn() },
+  supabasePublic: { from: vi.fn() },
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logError: vi.fn(),
+}));
+
+import { useAlpacaAccount, calculateDailyPnL } from './useAlpacaAccount';
+import { useAlpacaPositions, calculatePositionMetrics } from './useAlpacaPositions';
+
+const mockFetch = vi.fn();
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useAlpacaAccount()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('is disabled when user is null', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useAlpacaAccount('paper'), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('is disabled when auth is not ready', () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: false });
+
+    const { result } = renderHook(() => useAlpacaAccount('paper'), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('fetches account data when authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    const mockAccount = {
+      success: true,
+      account: {
+        portfolio_value: 100000,
+        cash: 25000,
+        equity: 100000,
+        last_equity: 99000,
+        status: 'ACTIVE',
+      },
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAccount),
+    });
+
+    const { result } = renderHook(() => useAlpacaAccount('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.portfolio_value).toBe(100000);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/functions/v1/alpaca-account');
+    const body = JSON.parse(options.body);
+    expect(body.action).toBe('get-account');
+    expect(body.tradingMode).toBe('paper');
+  });
+
+  it('returns null when no credentials configured', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        success: false,
+        error: 'No Alpaca credentials found',
+      }),
+    });
+
+    const { result } = renderHook(() => useAlpacaAccount('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('throws on non-credential errors', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: false, error: 'Server error' }),
+    });
+
+    const { result } = renderHook(() => useAlpacaAccount('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 });
+  });
+});
+
+describe('calculateDailyPnL()', () => {
+  it('returns zero for null account', () => {
+    expect(calculateDailyPnL(null)).toEqual({ value: 0, percent: 0 });
+  });
+
+  it('calculates positive P&L', () => {
+    const account = { equity: 105000, last_equity: 100000 } as Parameters<typeof calculateDailyPnL>[0];
+    const result = calculateDailyPnL(account);
+    expect(result.value).toBe(5000);
+    expect(result.percent).toBeCloseTo(5.0);
+  });
+
+  it('calculates negative P&L', () => {
+    const account = { equity: 95000, last_equity: 100000 } as Parameters<typeof calculateDailyPnL>[0];
+    const result = calculateDailyPnL(account);
+    expect(result.value).toBe(-5000);
+    expect(result.percent).toBeCloseTo(-5.0);
+  });
+
+  it('handles zero last_equity', () => {
+    const account = { equity: 1000, last_equity: 0 } as Parameters<typeof calculateDailyPnL>[0];
+    const result = calculateDailyPnL(account);
+    expect(result.percent).toBe(0);
+  });
+
+  it('handles string values', () => {
+    const account = { equity: '105000', last_equity: '100000' } as unknown as Parameters<typeof calculateDailyPnL>[0];
+    const result = calculateDailyPnL(account);
+    expect(result.value).toBe(5000);
+  });
+});
+
+describe('useAlpacaPositions()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('is disabled when user is null', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useAlpacaPositions('paper'), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('fetches positions when authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    const mockPositions = {
+      success: true,
+      positions: [
+        { symbol: 'AAPL', qty: 10, market_value: 1500, unrealized_pl: 200 },
+        { symbol: 'MSFT', qty: 5, market_value: 2000, unrealized_pl: -50 },
+      ],
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPositions),
+    });
+
+    const { result } = renderHook(() => useAlpacaPositions('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it('returns empty array when no credentials', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        success: false,
+        error: 'No Alpaca credentials found',
+      }),
+    });
+
+    const { result } = renderHook(() => useAlpacaPositions('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('calculatePositionMetrics()', () => {
+  it('calculates aggregate metrics', () => {
+    const positions = [
+      { market_value: 5000, cost_basis: 4500, unrealized_pl: 500, unrealized_intraday_pl: 50 },
+      { market_value: 3000, cost_basis: 3200, unrealized_pl: -200, unrealized_intraday_pl: -30 },
+    ] as Parameters<typeof calculatePositionMetrics>[0];
+
+    const result = calculatePositionMetrics(positions);
+    expect(result.totalValue).toBe(8000);
+    expect(result.totalCost).toBe(7700);
+    expect(result.totalPnL).toBe(300);
+    expect(result.totalIntradayPnL).toBe(20);
+    expect(result.positionCount).toBe(2);
+  });
+
+  it('returns zeros for empty array', () => {
+    const result = calculatePositionMetrics([]);
+    expect(result.totalValue).toBe(0);
+    expect(result.positionCount).toBe(0);
+  });
+});

--- a/client/src/hooks/useDrops.test.ts
+++ b/client/src/hooks/useDrops.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for hooks/useDrops.ts and useDropsRealtime.ts
+ *
+ * Tests:
+ * - useDrops() - Fetches drops feed, CRUD mutations, like/unlike with optimistic updates
+ * - useDropsRealtime() - Subscribes to realtime changes
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock Supabase client
+const mockRpc = vi.fn();
+const mockChannel = vi.fn();
+const mockRemoveChannel = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    channel: (...args: unknown[]) => mockChannel(...args),
+    removeChannel: (...args: unknown[]) => mockRemoveChannel(...args),
+  },
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    channel: (...args: unknown[]) => mockChannel(...args),
+    removeChannel: (...args: unknown[]) => mockRemoveChannel(...args),
+  },
+}));
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logDebug: vi.fn(),
+  logError: vi.fn(),
+}));
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+import { useDrops } from './useDrops';
+import { useDropsRealtime } from './useDropsRealtime';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const mockFetch = vi.fn();
+
+describe('useDrops()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches drops feed via RPC', async () => {
+    const mockDrops = [
+      { id: 'd1', content: 'First drop', likes_count: 3, user_has_liked: false },
+      { id: 'd2', content: 'Second drop', likes_count: 1, user_has_liked: true },
+    ];
+    mockRpc.mockResolvedValue({ data: mockDrops, error: null });
+
+    const { result } = renderHook(() => useDrops('live'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockRpc).toHaveBeenCalledWith('get_drops_feed', {
+      feed_type: 'live',
+      user_id_param: 'user-1',
+      limit_count: 50,
+      offset_count: 0,
+    });
+    expect(result.current.drops).toHaveLength(2);
+  });
+
+  it('returns empty drops when RPC returns null', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: null });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.drops).toEqual([]);
+  });
+
+  it('throws on RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'Function failed' } });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+  });
+
+  it('returns isAuthenticated based on user', () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.userId).toBeUndefined();
+  });
+
+  it('has correct initial mutation states', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isCreating).toBe(false);
+    expect(result.current.isDeleting).toBe(false);
+    expect(result.current.isLiking).toBe(false);
+    expect(result.current.isUnliking).toBe(false);
+  });
+
+  it('creates a drop via fetch', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    // Mock localStorage for access token
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: 'new-drop', content: 'Hello' }]),
+    });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      result.current.createDrop({ content: 'Hello', is_public: true });
+    });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const [url, options] = mockFetch.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('/rest/v1/drops'),
+    ) || [];
+    expect(url).toContain('/rest/v1/drops');
+    expect(options.method).toBe('POST');
+
+    localStorage.removeItem('sb-test-auth-token');
+  });
+
+  it('toggleLike calls like when not currently liked', async () => {
+    const mockDrops = [
+      { id: 'd1', content: 'Test', likes_count: 0, user_has_liked: false },
+    ];
+    mockRpc.mockResolvedValue({ data: mockDrops, error: null });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const { result } = renderHook(() => useDrops(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.toggleLike('d1', false);
+    });
+
+    await waitFor(() => {
+      const likeCall = mockFetch.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('/rest/v1/drop_likes'),
+      );
+      expect(likeCall).toBeTruthy();
+    });
+
+    localStorage.removeItem('sb-test-auth-token');
+  });
+});
+
+describe('useDropsRealtime()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('subscribes to drops table changes', () => {
+    const mockSubscribe = vi.fn().mockReturnValue({});
+    const mockOn = vi.fn().mockReturnValue({ subscribe: mockSubscribe });
+    mockChannel.mockReturnValue({ on: mockOn });
+
+    renderHook(() => useDropsRealtime(), { wrapper: createWrapper() });
+
+    expect(mockChannel).toHaveBeenCalledWith('drops-realtime');
+    expect(mockOn).toHaveBeenCalledWith(
+      'postgres_changes',
+      expect.objectContaining({
+        event: '*',
+        schema: 'public',
+        table: 'drops',
+      }),
+      expect.any(Function),
+    );
+    expect(mockSubscribe).toHaveBeenCalled();
+  });
+
+  it('removes channel on unmount', () => {
+    const channel = {};
+    const mockSubscribe = vi.fn().mockReturnValue(channel);
+    const mockOn = vi.fn().mockReturnValue({ subscribe: mockSubscribe });
+    mockChannel.mockReturnValue({ on: mockOn });
+
+    const { unmount } = renderHook(() => useDropsRealtime(), { wrapper: createWrapper() });
+    unmount();
+
+    expect(mockRemoveChannel).toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useOrders.test.ts
+++ b/client/src/hooks/useOrders.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for hooks/useOrders.ts
+ *
+ * Tests:
+ * - useOrders() - Fetches trading orders from edge function
+ * - useSyncOrders() - Syncs orders from Alpaca
+ * - usePlaceOrder() - Places new orders
+ * - useCancelOrder() - Cancels existing orders
+ * - getOrderStatusColor / getOrderStatusVariant helpers
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock Supabase client
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn() },
+  supabasePublic: { from: vi.fn() },
+}));
+
+// Mock fetchWithRetry
+vi.mock('@/lib/fetchWithRetry', () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+import { useOrders, getOrderStatusColor, getOrderStatusVariant } from './useOrders';
+
+const mockFetch = vi.fn();
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useOrders()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('is disabled when user is null', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useOrders('paper'), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('is disabled when auth is not ready', () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: false });
+
+    const { result } = renderHook(() => useOrders('paper'), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('fetches orders when authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    const mockOrders = {
+      success: true,
+      orders: [
+        { id: 'o1', ticker: 'AAPL', side: 'buy', quantity: 10, status: 'filled' },
+      ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOrders),
+    });
+
+    const { result } = renderHook(() => useOrders('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalled();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/functions/v1/orders');
+    const body = JSON.parse(options.body);
+    expect(body.action).toBe('get-orders');
+    expect(body.trading_mode).toBe('paper');
+  });
+
+  it('handles fetch error', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ message: 'Unauthorized' }),
+    });
+
+    const { result } = renderHook(() => useOrders('paper'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('passes status filter to API', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, orders: [], total: 0 }),
+    });
+
+    renderHook(
+      () => useOrders('live', { status: 'open', limit: 10 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.status).toBe('open');
+    expect(body.limit).toBe(10);
+    expect(body.trading_mode).toBe('live');
+  });
+});
+
+describe('getOrderStatusColor()', () => {
+  it('returns green for filled', () => {
+    expect(getOrderStatusColor('filled')).toBe('text-green-600');
+  });
+
+  it('returns blue for partially_filled', () => {
+    expect(getOrderStatusColor('partially_filled')).toBe('text-blue-600');
+  });
+
+  it('returns yellow for new/accepted/pending_new', () => {
+    expect(getOrderStatusColor('new')).toBe('text-yellow-600');
+    expect(getOrderStatusColor('accepted')).toBe('text-yellow-600');
+    expect(getOrderStatusColor('pending_new')).toBe('text-yellow-600');
+  });
+
+  it('returns gray for canceled/expired', () => {
+    expect(getOrderStatusColor('canceled')).toBe('text-gray-500');
+    expect(getOrderStatusColor('expired')).toBe('text-gray-500');
+  });
+
+  it('returns red for rejected', () => {
+    expect(getOrderStatusColor('rejected')).toBe('text-red-600');
+  });
+
+  it('returns muted for unknown status', () => {
+    expect(getOrderStatusColor('unknown')).toBe('text-muted-foreground');
+  });
+});
+
+describe('getOrderStatusVariant()', () => {
+  it('returns default for filled', () => {
+    expect(getOrderStatusVariant('filled')).toBe('default');
+  });
+
+  it('returns secondary for pending states', () => {
+    expect(getOrderStatusVariant('new')).toBe('secondary');
+    expect(getOrderStatusVariant('accepted')).toBe('secondary');
+    expect(getOrderStatusVariant('partially_filled')).toBe('secondary');
+  });
+
+  it('returns destructive for rejected', () => {
+    expect(getOrderStatusVariant('rejected')).toBe('destructive');
+  });
+
+  it('returns outline for unknown status', () => {
+    expect(getOrderStatusVariant('unknown')).toBe('outline');
+  });
+});

--- a/client/src/hooks/useParties.test.ts
+++ b/client/src/hooks/useParties.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for hooks/useParties.ts
+ *
+ * Tests:
+ * - useParties() - Fetches party records from Supabase
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: { from: (...args: unknown[]) => mockFrom(...args) },
+  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+
+import { useParties } from './useParties';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+function tableChain(data: unknown) {
+  const terminal = { data, error: null };
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === 'then')
+        return (resolve: (v: unknown) => void) => Promise.resolve(terminal).then(resolve);
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+describe('useParties()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches parties from the parties table', async () => {
+    const mockData = [
+      { id: '1', code: 'D', name: 'Democratic Party', short_name: 'D', jurisdiction: 'us', color: '#0000FF' },
+      { id: '2', code: 'R', name: 'Republican Party', short_name: 'R', jurisdiction: 'us', color: '#FF0000' },
+      { id: '3', code: 'LAB', name: 'Labour Party', short_name: 'Lab', jurisdiction: 'uk', color: '#E4003B' },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useParties(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('parties');
+    expect(result.current.data).toHaveLength(3);
+    expect(result.current.data?.[0].code).toBe('D');
+  });
+
+  it('returns empty array when no parties exist', async () => {
+    mockFrom.mockReturnValue(tableChain(null));
+
+    const { result } = renderHook(() => useParties(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('throws on Supabase error', async () => {
+    const errorTerminal = { data: null, error: { message: 'Table not found' } };
+    const handler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'then')
+          return (resolve: (v: unknown) => void) => Promise.resolve(errorTerminal).then(resolve);
+        return vi.fn().mockReturnValue(new Proxy({}, handler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, handler));
+
+    const { result } = renderHook(() => useParties(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/client/src/hooks/useReferencePortfolio.test.ts
+++ b/client/src/hooks/useReferencePortfolio.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for hooks/useReferencePortfolio.ts
+ *
+ * Tests:
+ * - useReferencePortfolioState() - Portfolio state with config join
+ * - useReferencePortfolioPositions() - Open/closed positions
+ * - useReferencePortfolioTrades() - Trade history with pagination
+ * - useReferencePortfolioPerformance() - Performance snapshots from edge function
+ * - useReferencePortfolioConfig() - Portfolio configuration
+ * - useMarketStatus() - Client-side market hours check
+ * - useReferencePortfolioSummary() - Computed summary metrics
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+const mockFunctionsInvoke = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    functions: { invoke: (...args: unknown[]) => mockFunctionsInvoke(...args) },
+  },
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    functions: { invoke: (...args: unknown[]) => mockFunctionsInvoke(...args) },
+  },
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logError: vi.fn(),
+}));
+
+import {
+  useReferencePortfolioState,
+  useReferencePortfolioPositions,
+  useReferencePortfolioTrades,
+  useReferencePortfolioPerformance,
+  useReferencePortfolioConfig,
+  useMarketStatus,
+  useReferencePortfolioSummary,
+} from './useReferencePortfolio';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+function singleChain(data: unknown) {
+  const terminal = { data, error: null };
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === 'single') return vi.fn().mockResolvedValue(terminal);
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function tableChain(data: unknown, opts?: { count?: number }) {
+  const terminal = { data, error: null, count: opts?.count ?? null };
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === 'then')
+        return (resolve: (v: unknown) => void) => Promise.resolve(terminal).then(resolve);
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+describe('useReferencePortfolioState()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches portfolio state with config join', async () => {
+    const mockState = {
+      id: 's1',
+      portfolio_value: 100000,
+      cash: 25000,
+      total_return: 5000,
+      total_return_pct: 5.0,
+      day_return: 200,
+      day_return_pct: 0.2,
+      win_rate: 0.65,
+      sharpe_ratio: 1.2,
+      max_drawdown: -3.5,
+      open_positions: 5,
+      total_trades: 50,
+      alpha: 2.3,
+      config: { id: 'c1', is_active: true },
+    };
+    mockFrom.mockReturnValue(singleChain(mockState));
+
+    const { result } = renderHook(() => useReferencePortfolioState(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('reference_portfolio_state');
+    expect(result.current.data?.portfolio_value).toBe(100000);
+    expect(result.current.data?.config?.is_active).toBe(true);
+  });
+
+  it('handles error', async () => {
+    const errorHandler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'single')
+          return vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } });
+        return vi.fn().mockReturnValue(new Proxy({}, errorHandler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, errorHandler));
+
+    const { result } = renderHook(() => useReferencePortfolioState(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useReferencePortfolioPositions()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches open positions by default', async () => {
+    const mockPositions = [
+      { id: 'pos1', ticker: 'AAPL', quantity: 10, is_open: true, unrealized_pl: 500 },
+      { id: 'pos2', ticker: 'MSFT', quantity: 5, is_open: true, unrealized_pl: -100 },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockPositions));
+
+    const { result } = renderHook(() => useReferencePortfolioPositions(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('reference_portfolio_positions');
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it('returns empty array on null data', async () => {
+    mockFrom.mockReturnValue(tableChain(null));
+
+    const { result } = renderHook(() => useReferencePortfolioPositions(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('useReferencePortfolioTrades()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches trades with pagination', async () => {
+    const mockTrades = [
+      { id: 'tx1', ticker: 'AAPL', transaction_type: 'buy', quantity: 10, price: 150 },
+    ];
+    const terminal = { data: mockTrades, error: null, count: 42 };
+    const handler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'then')
+          return (resolve: (v: unknown) => void) => Promise.resolve(terminal).then(resolve);
+        return vi.fn().mockReturnValue(new Proxy({}, handler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, handler));
+
+    const { result } = renderHook(() => useReferencePortfolioTrades(10, 0), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('reference_portfolio_transactions');
+    expect(result.current.data?.trades).toHaveLength(1);
+    expect(result.current.data?.total).toBe(42);
+  });
+});
+
+describe('useReferencePortfolioPerformance()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches performance snapshots from edge function', async () => {
+    const mockSnapshots = [
+      { id: 'snap1', snapshot_date: '2025-01-15', portfolio_value: 100000 },
+      { id: 'snap2', snapshot_date: '2025-01-16', portfolio_value: 101000 },
+    ];
+    mockFunctionsInvoke.mockResolvedValue({
+      data: { success: true, snapshots: mockSnapshots },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useReferencePortfolioPerformance('1w'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('reference-portfolio', {
+      body: { action: 'get-performance', timeframe: '1w' },
+    });
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it('throws on unsuccessful response', async () => {
+    mockFunctionsInvoke.mockResolvedValue({
+      data: { success: false, error: 'No data available' },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useReferencePortfolioPerformance(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useReferencePortfolioConfig()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches portfolio config', async () => {
+    const mockConfig = {
+      id: 'c1', name: 'Main', initial_capital: 100000, is_active: true,
+    };
+    mockFrom.mockReturnValue(singleChain(mockConfig));
+
+    const { result } = renderHook(() => useReferencePortfolioConfig(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('reference_portfolio_config');
+    expect(result.current.data?.is_active).toBe(true);
+  });
+});
+
+describe('useMarketStatus()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns market status', async () => {
+    const { result } = renderHook(() => useMarketStatus(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveProperty('isOpen');
+    expect(typeof result.current.data?.isOpen).toBe('boolean');
+  });
+});
+
+describe('useReferencePortfolioSummary()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('computes summary from portfolio state', async () => {
+    const mockState = {
+      id: 's1', portfolio_value: 105000, total_return: 5000, total_return_pct: 5.0,
+      day_return: 200, day_return_pct: 0.2, win_rate: 0.65, sharpe_ratio: 1.2,
+      max_drawdown: -3.5, open_positions: 5, total_trades: 50, alpha: 2.3,
+      config: { id: 'c1', is_active: true },
+    };
+    mockFrom.mockReturnValue(singleChain(mockState));
+
+    const { result } = renderHook(() => useReferencePortfolioSummary(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.summary?.portfolioValue).toBe(105000);
+    expect(result.current.summary?.totalReturnPct).toBe(5.0);
+    expect(result.current.summary?.isActive).toBe(true);
+    expect(result.current.summary?.alpha).toBe(2.3);
+  });
+
+  it('returns null summary when no state', async () => {
+    mockFrom.mockReturnValue(singleChain(null));
+
+    const { result } = renderHook(() => useReferencePortfolioSummary(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.summary).toBeNull();
+  });
+});

--- a/client/src/hooks/useSignalPlayground.test.ts
+++ b/client/src/hooks/useSignalPlayground.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for hooks/useSignalPlayground.ts
+ *
+ * Tests:
+ * - useSignalPlayground() - Signal generation playground with debounced API calls
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+// Mock Supabase client (needed by transitive imports)
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: { from: vi.fn() },
+  supabase: { from: vi.fn() },
+}));
+
+import { useSignalPlayground } from './useSignalPlayground';
+
+const mockFetch = vi.fn();
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useSignalPlayground()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        signals: [
+          { ticker: 'AAPL', signal_type: 'buy', confidence_score: 0.75 },
+        ],
+        stats: { totalSignals: 1, buyCount: 1, holdCount: 0, mlEnhancedCount: 0 },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns default weights initially', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    expect(result.current.weights).toBeDefined();
+    expect(result.current.hasChanges).toBe(false);
+    expect(result.current.modifiedCount).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('accepts initial weights that differ from defaults', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(
+      () => useSignalPlayground({ initialWeights: { baseConfidence: 0.9 } }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.weights.baseConfidence).toBe(0.9);
+    expect(result.current.hasChanges).toBe(true);
+    expect(result.current.modifiedCount).toBeGreaterThan(0);
+    vi.useRealTimers();
+  });
+
+  it('updates a single weight from defaults', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.updateWeight('baseConfidence', 0.9);
+    });
+
+    expect(result.current.weights.baseConfidence).toBe(0.9);
+    expect(result.current.hasChanges).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('updates multiple weights at once', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.updateWeights({ baseConfidence: 0.9, bipartisanBonus: 0.3 });
+    });
+
+    expect(result.current.weights.baseConfidence).toBe(0.9);
+    expect(result.current.weights.bipartisanBonus).toBe(0.3);
+    vi.useRealTimers();
+  });
+
+  it('resets to defaults', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(
+      () => useSignalPlayground({ initialWeights: { baseConfidence: 0.9 } }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.hasChanges).toBe(true);
+
+    act(() => {
+      result.current.resetToDefaults();
+    });
+
+    expect(result.current.hasChanges).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('sets lookback days', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setLookbackDays(30);
+    });
+
+    expect(result.current.lookbackDays).toBe(30);
+    vi.useRealTimers();
+  });
+
+  it('sets user lambda', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setUserLambda('return signal;');
+    });
+
+    expect(result.current.userLambda).toBe('return signal;');
+    vi.useRealTimers();
+  });
+
+  it('tracks debouncing state', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.updateWeight('baseConfidence', 0.8);
+    });
+
+    expect(result.current.isDebouncing).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(result.current.isDebouncing).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('has mlEnabled always true', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+    expect(result.current.mlEnabled).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('returns signals from preview response', async () => {
+    // Use real timers for async test so waitFor works
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    // Wait for debounce (500ms) + fetch + query state update
+    await vi.waitFor(() => {
+      expect(result.current.signals.length).toBeGreaterThan(0);
+    }, { timeout: 3000 });
+
+    expect(result.current.signals[0].ticker).toBe('AAPL');
+  });
+
+  it('calls edge function with correct URL', async () => {
+    const { result } = renderHook(() => useSignalPlayground(), { wrapper: createWrapper() });
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    }, { timeout: 2000 });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/functions/v1/trading-signals/preview-signals');
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/client/src/hooks/useSignalPresets.test.ts
+++ b/client/src/hooks/useSignalPresets.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for hooks/useSignalPresets.ts
+ *
+ * Tests:
+ * - useSignalPresets() - CRUD operations on signal weight presets
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: { from: (...args: unknown[]) => mockFrom(...args) },
+  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logDebug: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { useSignalPresets } from './useSignalPresets';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+function tableChain(data: unknown) {
+  const terminal = { data, error: null };
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === 'then')
+        return (resolve: (v: unknown) => void) => Promise.resolve(terminal).then(resolve);
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+describe('useSignalPresets()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear localStorage
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('fetches presets from signal_weight_presets table', async () => {
+    const mockPresets = [
+      { id: 'p1', name: 'Aggressive', user_id: 'u1', is_public: false, created_at: '2025-01-01' },
+      { id: 'p2', name: 'Conservative', user_id: null, is_public: true, created_at: '2025-01-02' },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockPresets));
+
+    const { result } = renderHook(() => useSignalPresets(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockFrom).toHaveBeenCalledWith('signal_weight_presets');
+    expect(result.current.presets).toHaveLength(2);
+  });
+
+  it('separates user and system presets', async () => {
+    const mockPresets = [
+      { id: 'p1', name: 'My Preset', user_id: 'u1', is_public: false },
+      { id: 'p2', name: 'System Preset', user_id: null, is_public: true },
+      { id: 'p3', name: 'Another User', user_id: 'u2', is_public: true },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockPresets));
+
+    const { result } = renderHook(() => useSignalPresets(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.userPresets).toHaveLength(2); // u1 and u2 presets
+    expect(result.current.systemPresets).toHaveLength(1); // null user_id + public
+  });
+
+  it('returns empty presets on null data', async () => {
+    mockFrom.mockReturnValue(tableChain(null));
+
+    const { result } = renderHook(() => useSignalPresets(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.presets).toEqual([]);
+  });
+
+  it('has correct initial mutation states', async () => {
+    mockFrom.mockReturnValue(tableChain([]));
+
+    const { result } = renderHook(() => useSignalPresets(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isCreating).toBe(false);
+    expect(result.current.isUpdating).toBe(false);
+    expect(result.current.isDeleting).toBe(false);
+    expect(result.current.createError).toBeNull();
+    expect(result.current.updateError).toBeNull();
+    expect(result.current.deleteError).toBeNull();
+  });
+
+  it('exposes refetch function', async () => {
+    mockFrom.mockReturnValue(tableChain([]));
+
+    const { result } = renderHook(() => useSignalPresets(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(typeof result.current.refetch).toBe('function');
+  });
+});

--- a/client/src/hooks/useStrategyFollow.test.ts
+++ b/client/src/hooks/useStrategyFollow.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for hooks/useStrategyFollow.ts
+ *
+ * Tests:
+ * - useStrategyFollow() - Strategy subscription management
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock environment variables
+vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_KEY', 'test-anon-key');
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('./useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock Supabase client
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn() },
+  supabasePublic: { from: vi.fn() },
+}));
+
+import { useStrategyFollow } from './useStrategyFollow';
+
+const mockFetch = vi.fn();
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useStrategyFollow()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('is disabled when user is null', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isFollowing).toBe(false);
+  });
+
+  it('is disabled when auth is not ready', () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: false });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('fetches subscription when authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    const mockResponse = {
+      isFollowing: true,
+      subscription: {
+        id: 's1',
+        strategy_type: 'reference',
+        trading_mode: 'paper',
+        is_active: true,
+      },
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockFetch).toHaveBeenCalled();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.action).toBe('get-subscription');
+    expect(result.current.isFollowing).toBe(true);
+    expect(result.current.subscription?.strategy_type).toBe('reference');
+  });
+
+  it('returns strategy name for reference type', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        isFollowing: true,
+        subscription: { id: 's1', strategy_type: 'reference', is_active: true },
+      }),
+    });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.followingName).toBe('Reference Strategy');
+  });
+
+  it('returns strategy name for preset type', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        isFollowing: true,
+        subscription: { id: 's1', strategy_type: 'preset', preset_name: 'Aggressive Growth' },
+      }),
+    });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.followingName).toBe('Aggressive Growth');
+  });
+
+  it('returns null followingName when not following', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    expect(result.current.followingName).toBeNull();
+  });
+
+  it('has correct initial mutation states', () => {
+    mockUseAuth.mockReturnValue({ user: null, authReady: true });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    expect(result.current.isSubscribing).toBe(false);
+    expect(result.current.isUnsubscribing).toBe(false);
+    expect(result.current.isSyncing).toBe(false);
+  });
+
+  it('handles fetch error', async () => {
+    mockUseAuth.mockReturnValue({ user: { email: 'test@test.com' }, authReady: true });
+
+    const mockToken = JSON.stringify({ access_token: 'test-token' });
+    localStorage.setItem('sb-test-auth-token', mockToken);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Unauthorized' }),
+    });
+
+    const { result } = renderHook(() => useStrategyFollow(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+  });
+});

--- a/client/src/hooks/useStrategyShowcase.test.ts
+++ b/client/src/hooks/useStrategyShowcase.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for hooks/useStrategyShowcase.ts
+ *
+ * Tests:
+ * - useStrategyShowcase() - Public strategies with like/unlike optimistic updates
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock Supabase client
+const mockRpc = vi.fn();
+const mockInsert = vi.fn();
+const mockDelete = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    from: vi.fn(),
+  },
+  supabase: {
+    from: (table: string) => {
+      if (table === 'strategy_likes') {
+        return {
+          insert: mockInsert,
+          delete: () => ({
+            eq: () => ({
+              eq: mockDelete,
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+  },
+}));
+
+// Mock useAuth
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { useStrategyShowcase } from './useStrategyShowcase';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useStrategyShowcase()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { id: 'user-1' } });
+  });
+
+  it('fetches public strategies via RPC', async () => {
+    const mockStrategies = [
+      { id: 's1', name: 'Aggressive', likes_count: 10, user_has_liked: false },
+      { id: 's2', name: 'Conservative', likes_count: 5, user_has_liked: true },
+    ];
+    mockRpc.mockResolvedValue({ data: mockStrategies, error: null });
+
+    const { result } = renderHook(() => useStrategyShowcase('recent'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockRpc).toHaveBeenCalledWith('get_public_strategies', {
+      sort_by: 'recent',
+      user_id_param: 'user-1',
+    });
+    expect(result.current.strategies).toHaveLength(2);
+  });
+
+  it('passes null user_id when not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    renderHook(() => useStrategyShowcase(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockRpc).toHaveBeenCalled());
+
+    expect(mockRpc).toHaveBeenCalledWith('get_public_strategies', {
+      sort_by: 'recent',
+      user_id_param: null,
+    });
+  });
+
+  it('returns isAuthenticated based on user', () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const { result } = renderHook(() => useStrategyShowcase(), { wrapper: createWrapper() });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('returns empty array on null data', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: null });
+
+    const { result } = renderHook(() => useStrategyShowcase(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.strategies).toEqual([]);
+  });
+
+  it('handles RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'Function failed' } });
+
+    const { result } = renderHook(() => useStrategyShowcase(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+  });
+
+  it('has correct initial mutation states', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const { result } = renderHook(() => useStrategyShowcase(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isLiking).toBe(false);
+    expect(result.current.isUnliking).toBe(false);
+    expect(result.current.likeError).toBeNull();
+  });
+
+  it('supports popular sort option', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    renderHook(() => useStrategyShowcase('popular'), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockRpc).toHaveBeenCalled());
+
+    expect(mockRpc).toHaveBeenCalledWith('get_public_strategies', {
+      sort_by: 'popular',
+      user_id_param: 'user-1',
+    });
+  });
+});

--- a/client/src/hooks/useSupabaseData.test.ts
+++ b/client/src/hooks/useSupabaseData.test.ts
@@ -1,0 +1,590 @@
+/**
+ * Tests for hooks/useSupabaseData.ts
+ *
+ * Tests all network-dependent hooks:
+ * - useJurisdictions, usePoliticians, useTrades, useTradingDisclosures
+ * - useChartData, useChartYears, useTopTickers, useDashboardStats
+ * - usePoliticianDetail, useTickerDetail, useMonthDetail
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabasePublic: { from: (...args: unknown[]) => mockFrom(...args) },
+  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+
+import {
+  useJurisdictions,
+  usePoliticians,
+  useTrades,
+  useTradingDisclosures,
+  useChartData,
+  useChartYears,
+  useTopTickers,
+  useDashboardStats,
+  usePoliticianDetail,
+  useTickerDetail,
+  useMonthDetail,
+} from './useSupabaseData';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+// Helper to build chainable mock returning data
+function chainMock(data: unknown, opts?: { count?: number }) {
+  const terminal = {
+    data,
+    error: null,
+    count: opts?.count ?? null,
+  };
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  // Each method returns `chain` so chaining works in any order,
+  // except terminal methods return the resolved value.
+  const terminalFn = vi.fn().mockResolvedValue(terminal);
+  const self = () =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop: string) {
+          if (['maybeSingle', 'single'].includes(prop)) return terminalFn;
+          if (!chain[prop]) {
+            chain[prop] = vi.fn().mockReturnValue(self());
+          }
+          return chain[prop];
+        },
+      },
+    );
+
+  // The outer select also needs to resolve when awaited
+  const root = self();
+  // Make the root promise-like so `const { data } = await query` works
+  (root as Record<string, unknown>).then = (resolve: (val: unknown) => void) =>
+    Promise.resolve(terminal).then(resolve);
+  return root;
+}
+
+// Simpler helper for terminal-chain patterns
+function tableChain(data: unknown, opts?: { count?: number }) {
+  const terminal = { data, error: null, count: opts?.count ?? null };
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => void) => Promise.resolve(terminal).then(resolve);
+      }
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+describe('useJurisdictions()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches jurisdictions ordered by name', async () => {
+    const mockData = [
+      { id: '1', code: 'us', name: 'United States', flag: 'US' },
+      { id: '2', code: 'uk', name: 'United Kingdom', flag: 'GB' },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useJurisdictions(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('jurisdictions');
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].code).toBe('us');
+  });
+
+  it('throws on Supabase error', async () => {
+    const errorTerminal = { data: null, error: { message: 'DB error' }, count: null };
+    const handler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'then')
+          return (resolve: (v: unknown) => void) => Promise.resolve(errorTerminal).then(resolve);
+        return vi.fn().mockReturnValue(new Proxy({}, handler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, handler));
+
+    const { result } = renderHook(() => useJurisdictions(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('usePoliticians()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches all politicians when no jurisdiction specified', async () => {
+    const mockData = [
+      {
+        id: 'p1', first_name: 'John', last_name: 'Doe', full_name: 'John Doe',
+        party: 'D', role: 'Senator', state_or_country: 'NY', district: null,
+        total_volume: 100000,
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => usePoliticians(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('politicians');
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].name).toBe('John Doe');
+    expect(result.current.data?.[0].chamber).toBe('Senator');
+  });
+
+  it('transforms politician data with fallback name', async () => {
+    const mockData = [
+      {
+        id: 'p2', first_name: 'Jane', last_name: 'Smith', full_name: null,
+        party: null, role: null, state_or_country: null, state: null, district: 'CA-12',
+        total_volume: 50000,
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => usePoliticians(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].name).toBe('Jane Smith');
+    expect(result.current.data?.[0].chamber).toBe('Unknown');
+    expect(result.current.data?.[0].party).toBe('Unknown');
+  });
+
+  it('maps jurisdiction_id from role correctly', async () => {
+    const mockData = [
+      { id: 'p1', full_name: 'MEP User', role: 'MEP', party: 'EPP', state_or_country: null, first_name: 'M', last_name: 'U', total_volume: 0, district: null },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => usePoliticians(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].jurisdiction_id).toBe('eu_parliament');
+  });
+});
+
+describe('useTrades()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches recent trades with politician join', async () => {
+    const mockData = [
+      {
+        id: 't1', asset_ticker: 'AAPL', asset_name: 'Apple Inc.',
+        transaction_type: 'purchase', amount_range_min: 1000, amount_range_max: 15000,
+        disclosure_date: '2025-01-15', status: 'active',
+        politician: {
+          id: 'p1', full_name: 'John Doe', first_name: 'John', last_name: 'Doe',
+          party: 'D', role: 'Senator', state_or_country: 'NY',
+        },
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useTrades(10), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('trading_disclosures');
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].ticker).toBe('AAPL');
+    expect(result.current.data?.[0].trade_type).toBe('buy');
+    expect(result.current.data?.[0].estimated_value).toBe(8000);
+  });
+
+  it('maps sale transaction_type to sell', async () => {
+    const mockData = [
+      {
+        id: 't2', asset_ticker: 'MSFT', asset_name: 'Microsoft',
+        transaction_type: 'sale', amount_range_min: 0, amount_range_max: 0,
+        disclosure_date: '2025-01-10', status: 'active', politician: null,
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useTrades(5), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].trade_type).toBe('sell');
+  });
+
+  it('handles null politician gracefully', async () => {
+    const mockData = [
+      {
+        id: 't3', asset_ticker: null, asset_name: 'Unknown', transaction_type: 'other',
+        amount_range_min: null, amount_range_max: null, disclosure_date: '2025-01-05',
+        status: 'active', politician: null,
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useTrades(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].ticker).toBe('');
+    expect(result.current.data?.[0].politician).toBeUndefined();
+  });
+});
+
+describe('useTradingDisclosures()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches disclosures with default options', async () => {
+    const mockData = [
+      {
+        id: 'd1', asset_ticker: 'GOOG', asset_name: 'Alphabet',
+        transaction_type: 'purchase', status: 'active',
+        politician: { id: 'p1', full_name: 'A B', first_name: 'A', last_name: 'B' },
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData, { count: 1 }));
+
+    const { result } = renderHook(() => useTradingDisclosures(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.disclosures).toHaveLength(1);
+    expect(result.current.data?.total).toBe(1);
+  });
+
+  it('pre-queries politicians for jurisdiction filter', async () => {
+    // First call: politicians query for pre-filtering
+    const politiciansData = [{ id: 'p1' }, { id: 'p2' }];
+    // Second call: disclosures query
+    const disclosuresData = [
+      {
+        id: 'd1', asset_ticker: 'AAPL', status: 'active', transaction_type: 'purchase',
+        politician: { id: 'p1', full_name: 'Rep User', first_name: 'Rep', last_name: 'User' },
+      },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return tableChain(politiciansData);
+      return tableChain(disclosuresData, { count: 1 });
+    });
+
+    const { result } = renderHook(
+      () => useTradingDisclosures({ jurisdiction: 'us' }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Should call from('politicians') first, then from('trading_disclosures')
+    expect(mockFrom).toHaveBeenCalledWith('politicians');
+    expect(mockFrom).toHaveBeenCalledWith('trading_disclosures');
+  });
+
+  it('short-circuits when no politicians match jurisdiction', async () => {
+    // Politicians query returns empty
+    mockFrom.mockReturnValue(tableChain([]));
+
+    const { result } = renderHook(
+      () => useTradingDisclosures({ jurisdiction: 'uk' }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.disclosures).toHaveLength(0);
+    expect(result.current.data?.total).toBe(0);
+  });
+
+  it('constructs politician name from first_name + last_name fallback', async () => {
+    const mockData = [
+      {
+        id: 'd1', status: 'active', transaction_type: 'purchase',
+        politician: { id: 'p1', full_name: null, first_name: 'Jane', last_name: 'Doe' },
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData, { count: 1 }));
+
+    const { result } = renderHook(() => useTradingDisclosures(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.disclosures[0].politician?.name).toBe('Jane Doe');
+  });
+});
+
+describe('useChartData()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches chart data with trailing12 default', async () => {
+    const mockData = [
+      { id: '1', month: 1, year: 2025, buys: 100, sells: 50, volume: 1000000 },
+      { id: '2', month: 2, year: 2025, buys: 120, sells: 60, volume: 1200000 },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useChartData(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('chart_data');
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].month).toContain("Jan '25");
+  });
+
+  it('formats month labels correctly', async () => {
+    const mockData = [
+      { id: '1', month: 12, year: 2024, buys: 50, sells: 25, volume: 500000 },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useChartData('all'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].month).toBe("Dec '24");
+  });
+});
+
+describe('useChartYears()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns unique years from chart data', async () => {
+    const mockData = [
+      { year: 2025 }, { year: 2025 }, { year: 2024 }, { year: 2024 }, { year: 2023 },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useChartYears(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([2025, 2024, 2023]);
+  });
+});
+
+describe('useTopTickers()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches top tickers from view', async () => {
+    const mockData = [
+      { ticker: 'AAPL', name: 'Apple Inc.', trade_count: 200, total_volume: 5000000 },
+      { ticker: 'MSFT', name: null, trade_count: 150, total_volume: 3000000 },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockData));
+
+    const { result } = renderHook(() => useTopTickers(5), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('top_tickers');
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].ticker).toBe('AAPL');
+    expect(result.current.data?.[0].count).toBe(200);
+    // Falls back to ticker when name is null
+    expect(result.current.data?.[1].name).toBe('MSFT');
+  });
+});
+
+describe('useDashboardStats()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches dashboard stats by fixed ID', async () => {
+    const mockStats = {
+      id: '00000000-0000-0000-0000-000000000001',
+      total_trades: 5000, total_volume: 100000000,
+      active_politicians: 300, jurisdictions_tracked: 4,
+      average_trade_size: 20000, recent_filings: 150,
+    };
+
+    // First call returns data via maybeSingle
+    const terminal = { data: mockStats, error: null };
+    const handler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'maybeSingle') return vi.fn().mockResolvedValue(terminal);
+        return vi.fn().mockReturnValue(new Proxy({}, handler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, handler));
+
+    const { result } = renderHook(() => useDashboardStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFrom).toHaveBeenCalledWith('dashboard_stats');
+    expect(result.current.data?.total_trades).toBe(5000);
+  });
+
+  it('falls back to most recent row when fixed ID not found', async () => {
+    const mockStats = {
+      id: 'other-id', total_trades: 3000, total_volume: 50000000,
+    };
+
+    // First maybeSingle returns null, second returns data
+    let callCount = 0;
+    const handler: ProxyHandler<object> = {
+      get(_target, prop: string) {
+        if (prop === 'maybeSingle') {
+          callCount++;
+          if (callCount === 1) return vi.fn().mockResolvedValue({ data: null, error: null });
+          return vi.fn().mockResolvedValue({ data: mockStats, error: null });
+        }
+        return vi.fn().mockReturnValue(new Proxy({}, handler));
+      },
+    };
+    mockFrom.mockReturnValue(new Proxy({}, handler));
+
+    const { result } = renderHook(() => useDashboardStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.total_trades).toBe(3000);
+  });
+});
+
+describe('usePoliticianDetail()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is disabled when politicianId is null', () => {
+    const { result } = renderHook(() => usePoliticianDetail(null), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('fetches politician with trade stats', async () => {
+    const mockPolitician = {
+      id: 'p1', first_name: 'John', last_name: 'Doe', full_name: 'John Doe',
+      party: 'D', role: 'Senator', state_or_country: 'NY', district: null,
+    };
+    const mockTrades = [
+      { id: 't1', transaction_type: 'purchase', asset_ticker: 'AAPL', amount_range_min: 1000, amount_range_max: 5000, status: 'active' },
+      { id: 't2', transaction_type: 'sale', asset_ticker: 'AAPL', amount_range_min: 2000, amount_range_max: 10000, status: 'active' },
+      { id: 't3', transaction_type: 'purchase', asset_ticker: 'MSFT', amount_range_min: null, amount_range_max: null, status: 'active' },
+      { id: 't4', transaction_type: 'holding', asset_ticker: 'GOOG', amount_range_min: 500, amount_range_max: 1000, status: 'active' },
+      { id: 't5', transaction_type: 'gift', asset_ticker: null, amount_range_min: 0, amount_range_max: 0, status: 'active' },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // politicians query with .single()
+        const singleFn = vi.fn().mockResolvedValue({ data: mockPolitician, error: null });
+        const handler: ProxyHandler<object> = {
+          get(_target, prop: string) {
+            if (prop === 'single') return singleFn;
+            return vi.fn().mockReturnValue(new Proxy({}, handler));
+          },
+        };
+        return new Proxy({}, handler);
+      }
+      // trading_disclosures query
+      return tableChain(mockTrades);
+    });
+
+    const { result } = renderHook(() => usePoliticianDetail('p1'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.name).toBe('John Doe');
+    expect(result.current.data?.buyCount).toBe(2);
+    expect(result.current.data?.sellCount).toBe(1);
+    expect(result.current.data?.holdingCount).toBe(1);
+    expect(result.current.data?.otherCount).toBe(1); // gift
+    expect(result.current.data?.total_trades).toBe(5);
+    // Top tickers: AAPL (2 trades), MSFT (1), GOOG (1)
+    expect(result.current.data?.topTickers[0].ticker).toBe('AAPL');
+    expect(result.current.data?.topTickers[0].count).toBe(2);
+  });
+});
+
+describe('useTickerDetail()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is disabled when ticker is null', () => {
+    const { result } = renderHook(() => useTickerDetail(null), { wrapper: createWrapper() });
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('fetches ticker details with politician aggregation', async () => {
+    const mockTrades = [
+      {
+        id: 't1', asset_ticker: 'AAPL', asset_name: 'Apple Inc.',
+        transaction_type: 'purchase', amount_range_min: 1000, amount_range_max: 5000,
+        disclosure_date: '2025-01-15', status: 'active',
+        politician: { id: 'p1', full_name: 'John Doe', first_name: 'J', last_name: 'D', party: 'D' },
+      },
+      {
+        id: 't2', asset_ticker: 'AAPL', asset_name: 'Apple Inc.',
+        transaction_type: 'sale', amount_range_min: 2000, amount_range_max: 10000,
+        disclosure_date: '2025-01-10', status: 'active',
+        politician: { id: 'p1', full_name: 'John Doe', first_name: 'J', last_name: 'D', party: 'D' },
+      },
+      {
+        id: 't3', asset_ticker: 'AAPL', asset_name: 'Apple Inc.',
+        transaction_type: 'purchase', amount_range_min: 500, amount_range_max: 1000,
+        disclosure_date: '2025-01-05', status: 'active',
+        politician: { id: 'p2', full_name: 'Jane Smith', first_name: 'J', last_name: 'S', party: 'R' },
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockTrades));
+
+    const { result } = renderHook(() => useTickerDetail('AAPL'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.ticker).toBe('AAPL');
+    expect(result.current.data?.name).toBe('Apple Inc.');
+    expect(result.current.data?.totalTrades).toBe(3);
+    expect(result.current.data?.buyCount).toBe(2);
+    expect(result.current.data?.sellCount).toBe(1);
+    // Top politicians: John Doe (2 trades), Jane Smith (1)
+    expect(result.current.data?.topPoliticians[0].name).toBe('John Doe');
+    expect(result.current.data?.topPoliticians[0].count).toBe(2);
+  });
+
+  it('returns null for empty results', async () => {
+    mockFrom.mockReturnValue(tableChain([]));
+
+    const { result } = renderHook(() => useTickerDetail('ZZZZ'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useMonthDetail()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is disabled when month or year is null', () => {
+    const { result: r1 } = renderHook(() => useMonthDetail(null, 2025), { wrapper: createWrapper() });
+    expect(r1.current.isFetching).toBe(false);
+
+    const { result: r2 } = renderHook(() => useMonthDetail(1, null), { wrapper: createWrapper() });
+    expect(r2.current.isFetching).toBe(false);
+  });
+
+  it('fetches trades for a specific month', async () => {
+    const mockTrades = [
+      {
+        id: 't1', transaction_type: 'purchase', asset_ticker: 'AAPL', asset_name: 'Apple',
+        amount_range_min: 1000, amount_range_max: 5000, disclosure_date: '2025-01-15',
+        status: 'active',
+        politician: { id: 'p1', full_name: 'John Doe', first_name: 'J', last_name: 'D', party: 'D' },
+      },
+      {
+        id: 't2', transaction_type: 'sale', asset_ticker: 'MSFT', asset_name: 'Microsoft',
+        amount_range_min: 2000, amount_range_max: 10000, disclosure_date: '2025-01-20',
+        status: 'active',
+        politician: { id: 'p1', full_name: 'John Doe', first_name: 'J', last_name: 'D', party: 'D' },
+      },
+    ];
+    mockFrom.mockReturnValue(tableChain(mockTrades));
+
+    const { result } = renderHook(() => useMonthDetail(1, 2025), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.month).toBe(1);
+    expect(result.current.data?.year).toBe(2025);
+    expect(result.current.data?.label).toBe('Jan 2025');
+    expect(result.current.data?.totalTrades).toBe(2);
+    expect(result.current.data?.buyCount).toBe(1);
+    expect(result.current.data?.sellCount).toBe(1);
+    expect(result.current.data?.topTickers).toHaveLength(2);
+    expect(result.current.data?.topPoliticians).toHaveLength(1);
+    expect(result.current.data?.topPoliticians[0].count).toBe(2);
+  });
+});

--- a/client/src/hooks/useWalletAuth.test.ts
+++ b/client/src/hooks/useWalletAuth.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for hooks/useWalletAuth.ts
+ *
+ * Tests:
+ * - useWalletAuth() - 3-step wallet auth flow (nonce -> sign -> verify)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock wagmi hooks
+const mockUseAccount = vi.fn();
+const mockSignMessageAsync = vi.fn();
+vi.mock('wagmi', () => ({
+  useAccount: () => mockUseAccount(),
+  useSignMessage: () => ({ signMessageAsync: mockSignMessageAsync }),
+}));
+
+// Mock Supabase client
+const mockVerifyOtp = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: { verifyOtp: (...args: unknown[]) => mockVerifyOtp(...args) },
+    from: vi.fn(),
+  },
+  supabasePublic: { from: vi.fn() },
+}));
+
+// Mock fetchWithRetry
+const mockFetchWithRetry = vi.fn();
+vi.mock('@/lib/fetchWithRetry', () => ({
+  fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logDebug: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { useWalletAuth } from './useWalletAuth';
+
+describe('useWalletAuth()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAccount.mockReturnValue({ address: '0xabc123', isConnected: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns initial state', () => {
+    const { result } = renderHook(() => useWalletAuth());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.address).toBe('0xabc123');
+    expect(typeof result.current.authenticate).toBe('function');
+  });
+
+  it('returns disconnected state when wallet not connected', () => {
+    mockUseAccount.mockReturnValue({ address: undefined, isConnected: false });
+
+    const { result } = renderHook(() => useWalletAuth());
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeUndefined();
+  });
+
+  it('returns error when wallet not connected on authenticate', async () => {
+    mockUseAccount.mockReturnValue({ address: undefined, isConnected: false });
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('Wallet not connected');
+  });
+
+  it('completes full auth flow successfully', async () => {
+    // Step 1: nonce response
+    mockFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ message: 'Sign this message: nonce-123' }),
+    });
+
+    // Step 2: wallet signs
+    mockSignMessageAsync.mockResolvedValue('0xsignature');
+
+    // Step 3: verify response
+    mockFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        token: 'magic-link-token',
+        isNewUser: false,
+        userId: 'user-1',
+      }),
+    });
+
+    // Step 4: Supabase OTP verify
+    mockVerifyOtp.mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; isNewUser?: boolean; userId?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(true);
+    expect(authResult!.isNewUser).toBe(false);
+    expect(authResult!.userId).toBe('user-1');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    // Verify nonce request
+    expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+    const [nonceUrl, nonceOpts] = mockFetchWithRetry.mock.calls[0];
+    expect(nonceUrl).toContain('wallet-auth?action=nonce');
+    expect(JSON.parse(nonceOpts.body)).toEqual({ wallet_address: '0xabc123' });
+
+    // Verify sign was called with message
+    expect(mockSignMessageAsync).toHaveBeenCalledWith({
+      message: 'Sign this message: nonce-123',
+      account: '0xabc123',
+    });
+
+    // Verify verify request
+    const [verifyUrl, verifyOpts] = mockFetchWithRetry.mock.calls[1];
+    expect(verifyUrl).toContain('wallet-auth?action=verify');
+    const verifyBody = JSON.parse(verifyOpts.body);
+    expect(verifyBody.wallet_address).toBe('0xabc123');
+    expect(verifyBody.signature).toBe('0xsignature');
+    expect(verifyBody.message).toBe('Sign this message: nonce-123');
+
+    // Verify OTP
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      token_hash: 'magic-link-token',
+      type: 'magiclink',
+    });
+  });
+
+  it('handles nonce request failure', async () => {
+    mockFetchWithRetry.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Rate limited' }),
+    });
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('Rate limited');
+    expect(result.current.error).toBe('Rate limited');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles wallet signing rejection', async () => {
+    mockFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ message: 'Sign this' }),
+    });
+
+    mockSignMessageAsync.mockRejectedValue(new Error('User rejected'));
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('User rejected');
+    expect(result.current.error).toBe('User rejected');
+  });
+
+  it('handles verify request failure', async () => {
+    mockFetchWithRetry
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Sign this' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Invalid signature' }),
+      });
+
+    mockSignMessageAsync.mockResolvedValue('0xbad');
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('Invalid signature');
+  });
+
+  it('handles Supabase OTP sign-in error', async () => {
+    mockFetchWithRetry
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Sign this' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: 'tok', isNewUser: false, userId: 'u1' }),
+      });
+
+    mockSignMessageAsync.mockResolvedValue('0xsig');
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'Token expired' } });
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('Token expired');
+  });
+
+  it('skips OTP when no token in response', async () => {
+    mockFetchWithRetry
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Sign this' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ isNewUser: true, userId: 'u-new' }),
+      });
+
+    mockSignMessageAsync.mockResolvedValue('0xsig');
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; isNewUser?: boolean };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(true);
+    expect(authResult!.isNewUser).toBe(true);
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+  });
+
+  it('sets isLoading during authenticate', async () => {
+    let resolveNonce: (v: unknown) => void;
+    mockFetchWithRetry.mockReturnValueOnce(
+      new Promise((r) => { resolveNonce = r; })
+    );
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authPromise: Promise<unknown>;
+    act(() => {
+      authPromise = result.current.authenticate();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolveNonce!({
+        ok: false,
+        json: () => Promise.resolve({ error: 'fail' }),
+      });
+      await authPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles non-Error throws gracefully', async () => {
+    mockFetchWithRetry.mockRejectedValueOnce('string error');
+
+    const { result } = renderHook(() => useWalletAuth());
+
+    let authResult: { success: boolean; error?: string };
+    await act(async () => {
+      authResult = await result.current.authenticate();
+    });
+
+    expect(authResult!.success).toBe(false);
+    expect(authResult!.error).toBe('Authentication failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 new test files covering every network-dependent React hook in `client/src/hooks/`
- 168 new tests covering Supabase queries, edge function fetch calls, RPC calls, realtime subscriptions, and wallet auth flows
- Total suite now at **926 tests across 39 files**, all passing

## Hooks covered
| Hook File | Tests | Pattern |
|-----------|-------|---------|
| useSupabaseData (11 hooks) | 25 | Supabase `from().select()` chains |
| useParties | 3 | Supabase `from()` chain |
| useDrops + useDropsRealtime | 9 | RPC + realtime channel subscription |
| useAdmin | 7 | `auth.getSession()` + RPC `has_role` |
| useSignalPlayground | 11 | Edge function fetch with debounce |
| useSignalPresets | 5 | Supabase `from()` CRUD |
| useOrders + helpers | 12 | Edge function fetch + helper fns |
| useReferencePortfolio (7 hooks) | 14 | Supabase chains + edge function |
| useStrategyFollow | 8 | Edge function fetch |
| useStrategyShowcase | 7 | RPC + mutations |
| useAlpacaAccount + useAlpacaPositions | 15 | Edge function fetch + helpers |
| useWalletAuth | 11 | 3-step wallet auth flow |

## Test plan
- [x] All 926 tests pass locally (`npm test -- --run`)
- [x] CI should pass (tests only, no functional changes)

## Summary by Sourcery

Add comprehensive unit test coverage for all network-dependent React hooks that integrate with Supabase, edge functions, and Alpaca-related flows.

Tests:
- Add tests for all Supabase-backed data hooks covering jurisdictions, politicians, trades, disclosures, charts, and dashboard stats.
- Add tests for reference portfolio hooks including state, positions, trades, performance, config, market status, and summary selectors.
- Add tests for Alpaca account and positions hooks plus their P&L and aggregate metrics helper functions.
- Add tests for drops feed hooks including RPC-based fetching, CRUD operations, likes, and realtime subscriptions.
- Add tests for orders hooks covering authenticated edge-function fetching and status helper utilities.
- Add tests for signal playground and signal preset hooks including debounced preview calls and CRUD behavior.
- Add tests for strategy follow and strategy showcase hooks covering subscription state and public strategy retrieval.
- Add tests for parties, admin, and wallet auth hooks to validate their network-dependent behavior.