### PR TITLE
fix: add API key auth to edge function ETL calls

### DIFF
--- a/supabase/functions/ml-training/index.ts
+++ b/supabase/functions/ml-training/index.ts
@@ -6,7 +6,7 @@ import { corsHeaders } from '../_shared/cors.ts'
 // Configuration
 // ---------------------------------------------------------------------------
 const ETL_API_URL = Deno.env.get('ETL_API_URL') || 'https://politician-trading-etl.fly.dev'
-const ADMIN_KEY = Deno.env.get('ETL_ADMIN_KEY') || ''
+const ETL_API_KEY = Deno.env.get('ETL_ADMIN_API_KEY') || Deno.env.get('ETL_API_KEY') || ''
 
 // Champion/Challenger thresholds
 const MIN_ACCURACY_IMPROVEMENT = 0.02 // 2 percentage-point improvement
@@ -129,7 +129,7 @@ serve(async (req: Request) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Admin-Key': ADMIN_KEY,
+        'X-API-Key': ETL_API_KEY,
       },
       body: JSON.stringify({
         lookback_days: lookbackDays,
@@ -160,7 +160,7 @@ serve(async (req: Request) => {
       await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
 
       const statusResponse = await fetch(`${ETL_API_URL}/ml/train/${jobId}`, {
-        headers: { 'X-Admin-Key': ADMIN_KEY },
+        headers: { 'X-API-Key': ETL_API_KEY },
       })
 
       if (statusResponse.ok) {

--- a/supabase/functions/signal-feedback/index.ts
+++ b/supabase/functions/signal-feedback/index.ts
@@ -13,6 +13,15 @@ const log = {
       ...metadata
     }))
   },
+  warn: (message: string, metadata?: any) => {
+    console.warn(JSON.stringify({
+      level: 'WARN',
+      timestamp: new Date().toISOString(),
+      service: 'signal-feedback',
+      message,
+      ...metadata
+    }))
+  },
   error: (message: string, error?: any, metadata?: any) => {
     console.error(JSON.stringify({
       level: 'ERROR',

--- a/supabase/functions/trading-signals/index.ts
+++ b/supabase/functions/trading-signals/index.ts
@@ -1605,6 +1605,7 @@ const DEFAULT_WEIGHTS: SignalWeights = {
 // ML Integration Configuration
 // Call ETL directly for ML (Phoenix proxy adds latency)
 const ETL_API_URL = Deno.env.get('ETL_API_URL') || 'https://politician-trading-etl.fly.dev'
+const ETL_API_KEY = Deno.env.get('ETL_API_KEY') || ''
 // ML enabled by default - quick health check prevents blocking on cold starts
 const ML_ENABLED = Deno.env.get('ML_ENABLED') !== 'false'
 const ML_BLEND_WEIGHT = 0.2 // 20% ML, 80% heuristic (reduced from 0.4 to test if ML is adding noise)
@@ -1976,6 +1977,7 @@ async function checkMlModelAvailable(): Promise<boolean> {
 
     const response = await fetch(`${ETL_API_URL}/ml/models/active`, {
       method: 'GET',
+      headers: { 'X-API-Key': ETL_API_KEY },
       signal: controller.signal,
     })
 
@@ -2051,7 +2053,7 @@ async function getBatchMlPredictions(
 
     const response = await fetch(`${ETL_API_URL}/ml/batch-predict`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': ETL_API_KEY },
       body: JSON.stringify({ tickers, use_cache: true }),
       signal: controller.signal,
     })
@@ -2170,7 +2172,7 @@ async function applyUserLambda(
 
     const response = await fetch(`${ETL_API_URL}/signals/apply-lambda`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': ETL_API_KEY },
       body: JSON.stringify({
         signals,
         lambdaCode,


### PR DESCRIPTION
## Summary
- Edge functions calling the Python ETL service were missing `X-API-Key` headers, causing ML predictions to silently fail with 401 auth errors
- `trading-signals`: Added `ETL_API_KEY` env var and `X-API-Key` header to `checkMlModelAvailable`, `getBatchMlPredictions`, and `applyUserLambda` 
- `ml-training`: Fixed wrong header name (`X-Admin-Key` -> `X-API-Key`) that couldn't pass the ASGI auth middleware
- `signal-feedback`: Added missing `log.warn` method that caused 500 errors on evaluate-model
- Added `regenerate-signals` and `train-model` mcli commands for CLI-driven ML pipeline operations

## Test plan
- [x] Set `ETL_API_KEY` and `ETL_ADMIN_API_KEY` as Supabase edge function secrets
- [x] Deployed all 3 edge functions, verified ML predictions now return (148 predictions vs 0 before)
- [x] Ran `mcli run jobs test-feedback-loop -v` — all steps pass
- [x] Ran `mcli run jobs evaluate-model` — no more 500 error
- [x] Verified signal execution skips correctly (position limits, confidence thresholds)

## Summary by Sourcery

Add authenticated ML ETL integration to edge functions and expose CLI workflows for regenerating signals and training models.

New Features:
- Introduce mcli jobs to regenerate trading signals via the trading-signals edge function with configurable confidence, limit, and lookback parameters.
- Add an mcli job to trigger and optionally monitor ETL-driven ML model training with configurable data and outcome weighting options.

Bug Fixes:
- Ensure ml-training and trading-signals edge functions authenticate to the ETL service using the correct X-API-Key header and environment variables.
- Add a warn logging method to the signal-feedback edge function to prevent runtime errors when emitting warning logs.

Enhancements:
- Surface detailed statistics and progress information from regenerate-signals and train-model operations to the CLI output for better observability.