### PR TITLE
fix: prevent phantom short positions and repair risk metrics

### DIFF
--- a/client/src/components/reference-portfolio/RiskMetrics.tsx
+++ b/client/src/components/reference-portfolio/RiskMetrics.tsx
@@ -210,13 +210,13 @@ export function RiskMetrics() {
           <div>
             <p className="text-xs text-muted-foreground">Avg Win</p>
             <p className="text-sm font-semibold text-success">
-              {state?.avg_win ? `$${state.avg_win.toFixed(2)}` : 'N/A'}
+              {state?.avg_win ? `${state.avg_win.toFixed(2)}%` : 'N/A'}
             </p>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Avg Loss</p>
             <p className="text-sm font-semibold text-destructive">
-              {state?.avg_loss ? `$${Math.abs(state.avg_loss).toFixed(2)}` : 'N/A'}
+              {state?.avg_loss ? `${Math.abs(state.avg_loss).toFixed(2)}%` : 'N/A'}
             </p>
           </div>
         </div>

--- a/supabase/migrations/20260220110000_fix_risk_metrics.sql
+++ b/supabase/migrations/20260220110000_fix_risk_metrics.sql
@@ -1,0 +1,23 @@
+-- Fix Risk Metrics Migration
+-- Addresses data integrity issues:
+-- 1. winning_trades/losing_trades counters drifted from actual closed positions
+-- 2. Negative market_value on positions created by unintended short sells
+-- 3. profit_factor, win_rate, avg_win, avg_loss out of sync
+
+-- ============================================================================
+-- 1. Fix positions with negative market_value
+-- These were created when sell orders were placed against non-existent Alpaca
+-- positions, causing Alpaca to open short positions with negative values.
+-- ============================================================================
+UPDATE reference_portfolio_positions
+SET market_value = ABS(quantity * COALESCE(current_price, entry_price)),
+    updated_at = NOW()
+WHERE market_value < 0
+  AND is_open = true;
+
+-- ============================================================================
+-- 2. Recalculate portfolio state from ground truth (closed positions)
+-- Uses the existing recalculate_portfolio_state() function from migration
+-- 20260128133800_fix_portfolio_state_sync.sql
+-- ============================================================================
+SELECT public.recalculate_portfolio_state();


### PR DESCRIPTION
## Summary
- **avg_win/avg_loss** now display as percentages (16.37%) instead of dollars ($16.37)
- **recalculateTradeMetrics()** helper recomputes all trade metrics from closed positions ground truth, replacing inline counter increments that caused drift
- **Alpaca position verification** before every sell order prevents creating unintended short positions
- **Short position filtering** in all 3 Alpaca sync paths (handleUpdatePositions, syncPositionsWithAlpaca, handleGetPositions)
- **market_value** clamped non-negative for long positions
- **SQL migration** heals existing negative market_value and recalculates counters

## Root Cause
Sell orders were placed without verifying position existence in Alpaca. When positions didn't exist (already closed or never filled), Alpaca opened short positions instead of rejecting. Negative market_value from shorts corrupted all downstream metrics.

## Test plan
- [ ] Deploy edge function: `npx supabase functions deploy reference-portfolio`
- [ ] Run migration: `npx supabase db push --linked`
- [ ] Verify at govmarket.trade/reference-portfolio:
  - avg_win shows `16.37%` not `$16.37`
  - winning_trades/losing_trades match actual closed positions
  - No negative market_value in open positions
- [ ] Monitor next sell cycle — should see Alpaca position verification logs

## Summary by Sourcery

Improve reference portfolio trade integrity by preventing unintended short positions and recalculating risk metrics from closed-position ground truth.

New Features:
- Add a helper to recompute all trade metrics from closed positions and persist them to portfolio state.
- Introduce an Alpaca position verification helper to check live positions before submitting sell orders.

Bug Fixes:
- Prevent creation and syncing of unintended Alpaca short positions by skipping shorts and validating position existence before sells.
- Clamp long-position market values to be non-negative when ingesting Alpaca data.
- Align avg_win and avg_loss semantics to use percentage returns instead of dollar amounts in the UI.

Enhancements:
- Recalculate trade metrics automatically after sell executions and position updates to keep state in sync with realized P&L.

Chores:
- Add a SQL migration to repair existing negative market values and recalculate portfolio state from ground truth.