### PR TITLE
fix: close orphaned positions and resolve trading-signals timeout

### DIFF
--- a/supabase/migrations/20260220160000_fix_signals_index_and_exit_reasons.sql
+++ b/supabase/migrations/20260220160000_fix_signals_index_and_exit_reasons.sql
@@ -1,0 +1,16 @@
+-- Fix trading_signals timeout: add composite partial index for the primary query pattern
+-- WHERE is_active = true ORDER BY created_at DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_trading_signals_active_created
+  ON trading_signals(created_at DESC)
+  WHERE is_active = true;
+
+-- Fix exit_reason CHECK constraint: add 'position_not_found' and 'alpaca_closed'
+-- These are needed by handleUpdatePositions() and handleCheckExits() for reconciliation
+-- when Alpaca has closed a position but the DB still has it as open.
+-- The original constraint only allowed: signal, stop_loss, take_profit, manual, rebalance
+ALTER TABLE reference_portfolio_positions
+  DROP CONSTRAINT IF EXISTS reference_portfolio_positions_exit_reason_check;
+
+ALTER TABLE reference_portfolio_positions
+  ADD CONSTRAINT reference_portfolio_positions_exit_reason_check
+  CHECK (exit_reason IN ('signal', 'stop_loss', 'take_profit', 'manual', 'rebalance', 'position_not_found', 'alpaca_closed', 'trailing_stop', 'timeout'));


### PR DESCRIPTION
## Summary
- **Position sync**: `handleUpdatePositions()`, `handleCheckExits()`, and `syncPositionsWithAlpaca()` now properly close DB positions that are absent from Alpaca (exit_reason='alpaca_closed') instead of silently using stale values — fixes the 95% position concentration / 11% capital utilization mismatch
- **Exit check reorder**: `handleCheckExits()` now verifies Alpaca position existence BEFORE checking exit thresholds, so orphaned positions are always caught regardless of price levels
- **Trading signals timeout**: Consolidated 3 sequential queries into 1 using PostgREST `count='exact'`, added composite partial index `idx_trading_signals_active_created`
- **Schema**: Expanded `exit_reason` CHECK constraint to include `position_not_found`, `alpaca_closed`, `trailing_stop`, `timeout`

## Test plan
- [ ] Verify trading-signals page loads without timeout at https://govmarket.trade/trading-signals
- [ ] Verify risk metrics panel updates correctly after next position sync cycle (positions_value, open_positions should reconcile with Alpaca)
- [ ] Check Fly.io logs for "DB-open position absent from Alpaca — marking closed" messages confirming reconciliation
- [ ] Verify exit threshold checks still trigger correctly (stop-loss, take-profit, trailing stop, time-based)

## Summary by Sourcery

Reconcile reference portfolio positions with Alpaca to eliminate orphaned open positions and optimize trading signals retrieval to prevent timeouts.

New Features:
- Add a composite partial index on active trading signals by creation time and use an exact-count, paginated query pattern to support efficient trading-signals listing.
- Extend the reference_portfolio_positions exit_reason schema to support new values for Alpaca reconciliation and time-based exits, including position_not_found, alpaca_closed, trailing_stop, and timeout.

Bug Fixes:
- Automatically close database positions that no longer exist in Alpaca during both periodic updates and snapshot syncs, ensuring open position counts and portfolio metrics match the broker.
- Ensure exit checks verify the existence of the corresponding Alpaca position before evaluating exit thresholds, preventing orphaned positions and incorrect state.
- Fix the trading-signals API timeout by consolidating data and count retrieval into a single query that aligns with a new index.

Enhancements:
- Adjust reference portfolio open position counts to exclude positions reconciled as closed during Alpaca synchronization for more accurate risk metrics.
- Improve logging around Alpaca reconciliation and snapshot syncs to surface when orphaned positions are detected and closed.