### PR TITLE
fix: resolve trading-signals page infinite spinner

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -87,11 +87,9 @@ const App = () => (
               } />
               <Route path="/trading-signals" element={
                 <ErrorBoundary name="Trading Signals">
-                  <ProtectedRoute>
-                    <Suspense fallback={<PageLoader />}>
-                      <TradingSignals />
-                    </Suspense>
-                  </ProtectedRoute>
+                  <Suspense fallback={<PageLoader />}>
+                    <TradingSignals />
+                  </Suspense>
                 </ErrorBoundary>
               } />
               <Route path="/admin/data-quality" element={

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -58,8 +58,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     );
 
     // Fallback: if auth listener doesn't fire within 2s, mark as ready anyway
+    // Must also clear loading — otherwise ProtectedRoute spinner hangs forever
     const timeout = setTimeout(() => {
       setAuthReady(true);
+      setLoading(false);
     }, 2000);
 
     return () => {


### PR DESCRIPTION
## Summary
- **Auth timeout bug**: `useAuth` 2-second fallback timeout set `authReady=true` but left `loading=true`, causing `ProtectedRoute` spinner to hang forever when Supabase auth listener doesn't fire (Brave shields, network issues)
- **Unnecessary auth wall**: Trading signals is read-only — removed `ProtectedRoute` wrapper. Signal generation already checks auth in component.

## Test plan
- [ ] Visit https://govmarket.trade/trading-signals in Brave browser (no login) — should load signals
- [ ] Visit in Chrome while logged in — should still work, "Generate Signals" button requires auth
- [ ] Visit other protected routes — should still require auth normally

## Summary by Sourcery

Fix authentication loading state fallback and remove unnecessary auth protection from the trading signals page.

Bug Fixes:
- Ensure the auth fallback timeout clears the loading state to prevent ProtectedRoute spinners from hanging indefinitely.

Enhancements:
- Make the trading signals route publicly accessible by removing the ProtectedRoute wrapper while preserving error boundaries and loading states.