### PR TITLE
fix: inject Supabase anon key via build args during deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
     - name: Deploy all services
       env:
         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+        VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
       run: mcli run services deploy-all
 
   # Build Summary

--- a/.mcli/workflows/client.py
+++ b/.mcli/workflows/client.py
@@ -57,11 +57,21 @@ def deploy(build_only: bool):
         return
 
     try:
+        import os
+
         # Build first
         console.print("\n[yellow]Building...[/yellow]")
         cmd = ["flyctl", "deploy", "--now"]
         if build_only:
             cmd = ["flyctl", "deploy", "--build-only"]
+
+        # Inject Supabase env vars as build args if available
+        supabase_url = os.environ.get("VITE_SUPABASE_URL")
+        supabase_key = os.environ.get("VITE_SUPABASE_PUBLISHABLE_KEY")
+        if supabase_url:
+            cmd.extend(["--build-arg", f"VITE_SUPABASE_URL={supabase_url}"])
+        if supabase_key:
+            cmd.extend(["--build-arg", f"VITE_SUPABASE_PUBLISHABLE_KEY={supabase_key}"])
 
         result = subprocess.run(
             cmd,

--- a/.mcli/workflows/services.sh
+++ b/.mcli/workflows/services.sh
@@ -47,7 +47,16 @@ deploy-server() {
 deploy-client() {
     echo "⚛️  Deploying React client..."
     cd "$PROJECT_ROOT/client"
-    fly deploy
+
+    local build_args=""
+    if [ -n "${VITE_SUPABASE_URL:-}" ]; then
+        build_args="$build_args --build-arg VITE_SUPABASE_URL=$VITE_SUPABASE_URL"
+    fi
+    if [ -n "${VITE_SUPABASE_PUBLISHABLE_KEY:-}" ]; then
+        build_args="$build_args --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$VITE_SUPABASE_PUBLISHABLE_KEY"
+    fi
+
+    fly deploy $build_args
     echo "✅ Client deployed: https://govmarket-client.fly.dev"
 }
 

--- a/.mcli/workflows/workflows.lock.json
+++ b/.mcli/workflows/workflows.lock.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated_at": "2026-02-17T14:26:18.082942Z",
+  "generated_at": "2026-04-02T19:17:17.318721Z",
   "commands": {
     "admin": {
       "file": "admin.py",
@@ -15,10 +15,23 @@
       "shell": null,
       "last_modified": "2026-02-12T11:17:31.794067Z"
     },
+    "alpaca": {
+      "file": "alpaca.py",
+      "language": "python",
+      "content_hash": "sha256:6997d2e915b60efeb630c5396e5a022a302c5bdac2237658cd024153a485f120",
+      "version": "1.0.0",
+      "group": "workflows",
+      "description": "Alpaca trading account management",
+      "author": "",
+      "requires": [],
+      "tags": [],
+      "shell": null,
+      "last_modified": "2026-02-20T13:07:43.518490Z"
+    },
     "client": {
       "file": "client.py",
       "language": "python",
-      "content_hash": "sha256:c680d27caaf40393c951dcd0d59985248f6356eb970dfa7a9224ed72311713cb",
+      "content_hash": "sha256:4ecadf77bbf85a483c3a035715b90ec992a4b91f6736b422297a4f20782d03df",
       "version": "1.0.0",
       "group": "workflows",
       "description": "Deploy and manage GovMarket client on Fly.io",
@@ -26,7 +39,7 @@
       "requires": [],
       "tags": [],
       "shell": null,
-      "last_modified": "2026-02-12T11:17:31.794777Z"
+      "last_modified": "2026-04-02T21:17:11.975220Z"
     },
     "context": {
       "file": "context.py",
@@ -44,7 +57,7 @@
     "etl": {
       "file": "etl.py",
       "language": "python",
-      "content_hash": "sha256:6836efaa52e881d0810a52de98ab66e1755da7ccd018e63ad8d7844b25159cd0",
+      "content_hash": "sha256:52446605e0eb4b342fcd18e9a1b154d7c15a204bf05990f00af68e68d6e92349",
       "version": "1.0.0",
       "group": "workflows",
       "description": "etl command",
@@ -52,12 +65,12 @@
       "requires": [],
       "tags": [],
       "shell": null,
-      "last_modified": "2026-02-17T15:25:55.764794Z"
+      "last_modified": "2026-03-08T13:46:54.303733Z"
     },
     "jobs": {
       "file": "jobs.py",
       "language": "python",
-      "content_hash": "sha256:8c94191e0a8f7ead9c52c75e7c828da641bd2af0f8ee984c0c929f22a402cf9b",
+      "content_hash": "sha256:7d887d0d239e7f6defe0c10b3b34325de0cba9b123c35753d6874b99065a49b0",
       "version": "1.0.0",
       "group": "workflows",
       "description": "Jobs command",
@@ -65,7 +78,7 @@
       "requires": [],
       "tags": [],
       "shell": null,
-      "last_modified": "2026-02-12T11:17:31.799097Z"
+      "last_modified": "2026-03-08T13:13:05.189853Z"
     },
     "politician_trading_tracker": {
       "file": "politician_trading_tracker.py",
@@ -96,7 +109,7 @@
     "services": {
       "file": "services.sh",
       "language": "shell",
-      "content_hash": "sha256:4f44c56595910f898c1d85dc656b415044e63f2e34e0ac423eb88d814a350bf2",
+      "content_hash": "sha256:f9a0c39a7341c97c567871b8d7ab3da23a73b98839fd42d77aab641fff75034e",
       "version": "1.0.0",
       "group": "workflows",
       "description": "Services command",
@@ -104,7 +117,7 @@
       "requires": [],
       "tags": [],
       "shell": "zsh",
-      "last_modified": "2026-02-12T11:17:31.800278Z"
+      "last_modified": "2026-04-02T21:16:55.398410Z"
     },
     "supabase": {
       "file": "supabase.py",
@@ -118,6 +131,19 @@
       "tags": [],
       "shell": null,
       "last_modified": "2026-02-12T11:17:31.800383Z"
+    },
+    "trading_research": {
+      "file": "trading_research.py",
+      "language": "python",
+      "content_hash": "sha256:19e944b6a2665473389a6afb1fb728fbe678fe6128ba11638e9ceef31239d474",
+      "version": "1.0.0",
+      "group": "research",
+      "description": "Autonomous trading parameter research loop (autoresearch-style)",
+      "author": "",
+      "requires": [],
+      "tags": [],
+      "shell": null,
+      "last_modified": "2026-03-13T15:59:19.378051Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- The deployed client has `REDACTED` literally baked into the JS bundle as the Supabase API key, causing all data fetching to fail with 401 errors
- Pass `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` as `--build-arg` to `flyctl deploy` when available in environment
- Added both values as GitHub secrets and wired them through CI

## Root Cause
When `client/fly.toml` was committed, the Supabase anon key was replaced with `REDACTED` (by secret scanner). Every deploy since has been building with an invalid key baked into the Vite bundle.

## Test plan
- [ ] CI passes (tests don't touch deploy logic)
- [ ] After merge, CI deploys to Fly.io with correct key injected
- [ ] Verify govmarket.trade tables load data (no more 401s)

## Summary by Sourcery

Inject Supabase environment variables into client deploys so the built frontend uses valid Supabase configuration.

New Features:
- Pass VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY as build arguments when deploying the client via shell and Python workflows.

Enhancements:
- Update the shared client deployment scripts to conditionally add Supabase-related build arguments based on available environment variables.
- Wire Supabase URL and publishable key into the CI deploy job via GitHub secrets so they are available during Fly.io deploys.